### PR TITLE
Lagt til Service-klasse for CaseRelation

### DIFF
--- a/src/main/java/no/nav/melosys/eessi/service/caserelation/CaseRelationService.java
+++ b/src/main/java/no/nav/melosys/eessi/service/caserelation/CaseRelationService.java
@@ -1,0 +1,40 @@
+package no.nav.melosys.eessi.service.caserelation;
+
+import java.util.Optional;
+import javax.transaction.Transactional;
+import no.nav.melosys.eessi.models.CaseRelation;
+import no.nav.melosys.eessi.repository.CaseRelationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CaseRelationService {
+
+    private final CaseRelationRepository caseRelationRepository;
+
+    @Autowired
+    public CaseRelationService(CaseRelationRepository caseRelationRepository) {
+        this.caseRelationRepository = caseRelationRepository;
+    }
+
+    public CaseRelation save(Long gsakSaksnummer, String rinaCaseId) {
+        CaseRelation caseRelation = new CaseRelation();
+        caseRelation.setRinaId(rinaCaseId);
+        caseRelation.setGsakSaksnummer(gsakSaksnummer);
+        caseRelationRepository.save(caseRelation);
+        return save(caseRelation);
+    }
+
+    @Transactional
+    public CaseRelation save(CaseRelation caseRelation) {
+        return caseRelationRepository.save(caseRelation);
+    }
+
+    public Optional<CaseRelation> findByRinaId(String rinaId) {
+        return caseRelationRepository.findByRinaId(rinaId);
+    }
+
+    public Optional<CaseRelation> findByGsakSaksnummer(Long gsakSaksnummer) {
+        return caseRelationRepository.findByGsakSaksnummer(gsakSaksnummer);
+    }
+}

--- a/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -5,10 +5,9 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.integration.eux.EuxConsumer;
-import no.nav.melosys.eessi.models.CaseRelation;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.sed.SED;
-import no.nav.melosys.eessi.repository.CaseRelationRepository;
+import no.nav.melosys.eessi.service.caserelation.CaseRelationService;
 import no.nav.melosys.eessi.service.joark.ParticipantInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,13 +17,13 @@ import org.springframework.stereotype.Service;
 public class EuxService {
 
     private final EuxConsumer euxConsumer;
-    private final CaseRelationRepository caseRelationRepository;
+    private final CaseRelationService caseRelationService;
 
     @Autowired
     public EuxService(EuxConsumer euxConsumer,
-                      CaseRelationRepository caseRelationRepository) {
+                      CaseRelationService caseRelationService) {
         this.euxConsumer = euxConsumer;
-        this.caseRelationRepository = caseRelationRepository;
+        this.caseRelationService = caseRelationService;
     }
 
     public JsonNode hentBuC(String rinaSaksnummer) throws IntegrationException {
@@ -59,10 +58,7 @@ public class EuxService {
         String documentId = map.get("documentId");
         log.info("Buc opprettet med id: {} og sed opprettet med id: {}", rinaCaseId, documentId);
 
-        CaseRelation caseRelation = new CaseRelation();
-        caseRelation.setRinaId(rinaCaseId);
-        caseRelation.setGsakSaksnummer(gsakSaksnummer);
-        caseRelationRepository.save(caseRelation);
+        caseRelationService.save(gsakSaksnummer, rinaCaseId);
         log.info("gsakSaksnummer {} lagret med rinaId {}", gsakSaksnummer, rinaCaseId);
 
         euxConsumer.sendSed(rinaCaseId, "!23", documentId);

--- a/src/main/java/no/nav/melosys/eessi/service/joark/OpprettInngaaendeJournalpostService.java
+++ b/src/main/java/no/nav/melosys/eessi/service/joark/OpprettInngaaendeJournalpostService.java
@@ -9,7 +9,7 @@ import no.nav.melosys.eessi.integration.gsak.Sak;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.models.CaseRelation;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
-import no.nav.melosys.eessi.repository.CaseRelationRepository;
+import no.nav.melosys.eessi.service.caserelation.CaseRelationService;
 import no.nav.melosys.eessi.service.dokkat.DokkatSedInfo;
 import no.nav.melosys.eessi.service.dokkat.DokkatService;
 import no.nav.melosys.eessi.service.eux.EuxService;
@@ -23,19 +23,19 @@ import static no.nav.melosys.eessi.service.joark.InngaaendeForsendelseMapper.cre
 public class OpprettInngaaendeJournalpostService {
 
     private final DokmotInngaaendeConsumer dokmotInngaaendeConsumer;
-    private final CaseRelationRepository caseRelationRepository;
+    private final CaseRelationService caseRelationService;
     private final DokkatService dokkatService;
     private final GsakService gsakService;
     private final EuxService euxService;
 
     @Autowired
     public OpprettInngaaendeJournalpostService(DokmotInngaaendeConsumer dokmotInngaaendeConsumer,
-                                               CaseRelationRepository caseRelationRepository,
+                                               CaseRelationService caseRelationService,
                                                DokkatService dokkatService,
                                                GsakService gsakService,
                                                EuxService euxService) {
         this.dokmotInngaaendeConsumer = dokmotInngaaendeConsumer;
-        this.caseRelationRepository = caseRelationRepository;
+        this.caseRelationService = caseRelationService;
         this.dokkatService = dokkatService;
         this.gsakService = gsakService;
         this.euxService = euxService;
@@ -57,7 +57,7 @@ public class OpprettInngaaendeJournalpostService {
     }
 
     private Sak getOrCreateSak(String rinaId, String aktoerId) throws IntegrationException {
-        Optional<Long> gsakId = caseRelationRepository.findByRinaId(rinaId)
+        Optional<Long> gsakId = caseRelationService.findByRinaId(rinaId)
                 .map(CaseRelation::getGsakSaksnummer);
 
         if (gsakId.isPresent()) {
@@ -79,7 +79,7 @@ public class OpprettInngaaendeJournalpostService {
         CaseRelation caseRelation = new CaseRelation();
         caseRelation.setRinaId(rinaId);
         caseRelation.setGsakSaksnummer(Long.parseLong(sak.getId()));
-        caseRelationRepository.save(caseRelation);
+        caseRelationService.save(caseRelation);
 
         log.info("Sak i gsak med id {} ble opprettet for rinaSak {}", sak.getId(), rinaId);
         return sak;

--- a/src/main/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostService.java
+++ b/src/main/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostService.java
@@ -9,7 +9,7 @@ import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.models.CaseRelation;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
-import no.nav.melosys.eessi.repository.CaseRelationRepository;
+import no.nav.melosys.eessi.service.caserelation.CaseRelationService;
 import no.nav.melosys.eessi.service.eux.EuxService;
 import no.nav.melosys.eessi.service.gsak.GsakService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,17 +24,17 @@ public class OpprettUtgaaendeJournalpostService {
     private final GsakService gsakService;
     private final DokarkivSedConsumer dokarkivSedConsumer;
     private final EuxService euxService;
-    private final CaseRelationRepository caseRelationRepository;
+    private final CaseRelationService caseRelationService;
 
     @Autowired
     public OpprettUtgaaendeJournalpostService(
             GsakService gsakService,
             DokarkivSedConsumer dokarkivSedConsumer, EuxService euxService,
-            CaseRelationRepository caseRelationRepository) {
+            CaseRelationService caseRelationService) {
         this.dokarkivSedConsumer = dokarkivSedConsumer;
         this.euxService = euxService;
         this.gsakService = gsakService;
-        this.caseRelationRepository = caseRelationRepository;
+        this.caseRelationService = caseRelationService;
     }
 
     //Returnerer journalpostId. Trengs returverdi?
@@ -42,7 +42,7 @@ public class OpprettUtgaaendeJournalpostService {
 
         byte[] pdf = euxService.hentSedPdf(sedSendt.getRinaSakId(), sedSendt.getRinaDokumentId());
 
-        Long gsakSaksnummer = caseRelationRepository.findByRinaId(sedSendt.getRinaSakId())
+        Long gsakSaksnummer = caseRelationService.findByRinaId(sedSendt.getRinaSakId())
                 .map(CaseRelation::getGsakSaksnummer).orElseThrow(() -> new NotFoundException("Saksrelasjon ikke funnet med rinaSakId " + sedSendt.getRinaSakId()));
 
         log.info("Henter gsak med id: {}", gsakSaksnummer);

--- a/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
+++ b/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
@@ -9,7 +9,7 @@ import no.nav.melosys.eessi.integration.eux.EuxConsumer;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.sed.BucType;
 import no.nav.melosys.eessi.models.sed.SED;
-import no.nav.melosys.eessi.repository.CaseRelationRepository;
+import no.nav.melosys.eessi.service.caserelation.CaseRelationService;
 import no.nav.melosys.eessi.service.joark.ParticipantInfo;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,7 +30,7 @@ public class EuxServiceTest {
     private EuxConsumer euxConsumer;
 
     @Mock
-    private CaseRelationRepository caseRelationRepository;
+    private CaseRelationService caseRelationService;
 
     @InjectMocks
     private EuxService euxService;
@@ -85,7 +85,7 @@ public class EuxServiceTest {
         verify(euxConsumer, times(1))
                 .sendSed(anyString(), anyString(), anyString());
 
-        verify(caseRelationRepository, times(1))
-                .save(any());
+        verify(caseRelationService, times(1))
+                .save(anyLong(), anyString());
     }
 }

--- a/src/test/java/no/nav/melosys/eessi/service/joark/OpprettInngaaendeJournalpostServiceTest.java
+++ b/src/test/java/no/nav/melosys/eessi/service/joark/OpprettInngaaendeJournalpostServiceTest.java
@@ -9,7 +9,7 @@ import no.nav.melosys.eessi.integration.gsak.Sak;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.models.CaseRelation;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
-import no.nav.melosys.eessi.repository.CaseRelationRepository;
+import no.nav.melosys.eessi.service.caserelation.CaseRelationService;
 import no.nav.melosys.eessi.service.dokkat.DokkatSedInfo;
 import no.nav.melosys.eessi.service.dokkat.DokkatService;
 import no.nav.melosys.eessi.service.eux.EuxService;
@@ -23,8 +23,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -34,7 +33,7 @@ public class OpprettInngaaendeJournalpostServiceTest {
     private DokmotInngaaendeConsumer dokmotInngaaendeConsumer;
 
     @Mock
-    private CaseRelationRepository caseRelationRepository;
+    private CaseRelationService caseRelationService;
 
     @Mock
     private DokkatService dokkatService;
@@ -62,7 +61,7 @@ public class OpprettInngaaendeJournalpostServiceTest {
                 .thenReturn(response);
 
         CaseRelation caseRelation = enhancedRandom.nextObject(CaseRelation.class);
-        when(caseRelationRepository.findByRinaId(anyString()))
+        when(caseRelationService.findByRinaId(anyString()))
                 .thenReturn(Optional.ofNullable(caseRelation));
 
         DokkatSedInfo dokkatSedInfo = enhancedRandom.nextObject(DokkatSedInfo.class);
@@ -93,7 +92,7 @@ public class OpprettInngaaendeJournalpostServiceTest {
         assertThat(journalpostId, is("11223344"));
 
         verify(dokmotInngaaendeConsumer, times(1)).create(any());
-        verify(caseRelationRepository, times(1)).findByRinaId(anyString());
+        verify(caseRelationService, times(1)).findByRinaId(anyString());
         verify(dokkatService, times(1)).hentMetadataFraDokkat(anyString());
         verify(gsakService, times(1)).getSak(anyLong());
         verify(gsakService, times(0)).createSak(any());
@@ -102,7 +101,7 @@ public class OpprettInngaaendeJournalpostServiceTest {
 
     @Test
     public void arkiverInngaaendeSed_expectCreateSak() throws Exception {
-        when(caseRelationRepository.findByRinaId(anyString()))
+        when(caseRelationService.findByRinaId(anyString()))
                 .thenReturn(Optional.empty());
 
         String journalpostId = opprettInngaaendeJournalpostService.arkiverInngaaendeSed(sedMottatt, "123123");
@@ -116,7 +115,7 @@ public class OpprettInngaaendeJournalpostServiceTest {
 
     @Test(expected = IntegrationException.class)
     public void arkiverInngaaendeSed_expectIntegrationException() throws Exception {
-        when(caseRelationRepository.findByRinaId(anyString()))
+        when(caseRelationService.findByRinaId(anyString()))
                 .thenReturn(Optional.empty());
 
         when(gsakService.createSak(any()))

--- a/src/test/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostServiceTest.java
+++ b/src/test/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostServiceTest.java
@@ -10,7 +10,7 @@ import no.nav.melosys.eessi.integration.gsak.Sak;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.models.CaseRelation;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
-import no.nav.melosys.eessi.repository.CaseRelationRepository;
+import no.nav.melosys.eessi.service.caserelation.CaseRelationService;
 import no.nav.melosys.eessi.service.eux.EuxService;
 import no.nav.melosys.eessi.service.gsak.GsakService;
 import org.junit.Before;
@@ -36,7 +36,7 @@ public class OpprettUtgaaendeJournalpostServiceTest {
     @Mock
     private EuxService euxService;
     @Mock
-    private CaseRelationRepository caseRelationRepository;
+    private CaseRelationService caseRelationService;
 
     @InjectMocks
     private OpprettUtgaaendeJournalpostService opprettUtgaaendeJournalpostService;
@@ -57,7 +57,7 @@ public class OpprettUtgaaendeJournalpostServiceTest {
         when(euxService.hentSedPdf(anyString(), anyString())).thenReturn(new byte[0]);
 
         CaseRelation caseRelation = enhancedRandom.nextObject(CaseRelation.class);
-        when(caseRelationRepository.findByRinaId(anyString())).thenReturn(Optional.of(caseRelation));
+        when(caseRelationService.findByRinaId(anyString())).thenReturn(Optional.of(caseRelation));
 
         when(dokarkivSedConsumer.create(any(ArkiverUtgaaendeSed.class))).thenReturn(response);
 
@@ -76,7 +76,7 @@ public class OpprettUtgaaendeJournalpostServiceTest {
 
     @Test(expected = NotFoundException.class)
     public void journalfoer_noCaseRelation_expectNotFoundException() throws Exception {
-        when(caseRelationRepository.findByRinaId(anyString())).thenReturn(Optional.empty());
+        when(caseRelationService.findByRinaId(anyString())).thenReturn(Optional.empty());
         opprettUtgaaendeJournalpostService.arkiverUtgaaendeSed(sedSendt);
     }
 }


### PR DESCRIPTION
Dette fordi det skjer noen ganger at rina sender ut sent sed på kafka-topic før transaksjonen faktisk er blitt committet. Service-klassen har en egen Transactional-metode som brukes for lagring.