### PR TITLE
Gb el landkoder

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -106,7 +106,7 @@ public class EuxService {
     }
 
     private boolean filtrerPåLandkode(Institusjon institusjon, String landkode) {
-        return landkode == null || landkode.equalsIgnoreCase(institusjon.getLandkode());
+        return StringUtils.isEmpty(landkode) || landkode.equalsIgnoreCase(institusjon.getLandkode());
     }
 
     public void opprettOgSendSed(SED sed, String rinaSaksnummer) throws IntegrationException {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -64,8 +64,8 @@ public final class LandkodeMapper {
     public static String mapTilNavLandkode(String landkode) {
         if ("UK".equalsIgnoreCase(landkode)) {
             return "GB";
-        } else if ("GR".equalsIgnoreCase(landkode)) {
-            return "EL";
+        } else if ("EL".equalsIgnoreCase(landkode)) {
+            return "GR";
         }
         return landkode;
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
@@ -196,6 +196,16 @@ public class EuxServiceTest {
     }
 
     @Test
+    public void hentMottakerinstitusjoner_laBuc04LandGR_forventEnInstitusjon() throws IntegrationException {
+        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("LA_BUC_04", "GR");
+        assertThat(institusjoner).hasSize(1);
+
+        Institusjon institusjon = institusjoner.get(0);
+        assertThat(institusjon.getAkronym()).isEqualTo("FK EL-TITTEI");
+        assertThat(institusjon.getLandkode()).isEqualTo("GR");
+    }
+
+    @Test
     public void sedErEndring_medFlereConversations_forventTrue() throws IntegrationException {
         String sedID = "3333";
         String rinaSaksnummer = "333222111";

--- a/melosys-eessi-app/src/test/resources/institusjoner.json
+++ b/melosys-eessi-app/src/test/resources/institusjoner.json
@@ -145,9 +145,23 @@
   },
   {
     "id": "UK:1",
-    "navn": "The Swedish Social Insurance Agency",
+    "navn": "The UK Social Insurance Agency",
     "akronym": "FK UK-TITTEI",
     "landkode": "UK",
+    "tilegnetBucs": [
+      {
+        "bucType": "LA_BUC_04",
+        "institusjonsrolle": "CounterParty",
+        "gyldigStartDato": "2018-02-28T23:00:00.000+0000",
+        "eessiklar": true
+      }
+    ]
+  },
+  {
+    "id": "EL:1",
+    "navn": "The Hellas Social Insurance Agency",
+    "akronym": "FK EL-TITTEI",
+    "landkode": "EL",
     "tilegnetBucs": [
       {
         "bucType": "LA_BUC_04",


### PR DESCRIPTION
Mapper alltid respons fra institusjons-endepunktet vi mottar fra eux-rina-api om til landkoder som samsvarer med det som er i bruk i NAV. Dette slik at Melosys aldri trenger å forholde seg til landkodene EL og UK.