### PR TITLE
MELOSYS-3438 - Sorter sed ved oppdatering

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedStatus.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedStatus.java
@@ -6,10 +6,10 @@ import org.springframework.util.StringUtils;
 
 @Getter
 public enum SedStatus {
-    UTKAST("UTKAST", "NEW"),
     SENDT("SENDT", "SENT"),
-    MOTTATT("MOTTATT", "RECEIVED"),
+    UTKAST("UTKAST", "NEW"),
     TOM("TOM", "EMPTY"),
+    MOTTATT("MOTTATT", "RECEIVED"),
     AVBRUTT("AVBRUTT", "CANCELLED");
 
     private final String norskStatus;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
@@ -1,8 +1,12 @@
 package no.nav.melosys.eessi.service.sed;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.controller.dto.OpprettSedDto;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
+import no.nav.melosys.eessi.controller.dto.SedStatus;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.models.SedType;
@@ -19,9 +23,6 @@ import no.nav.melosys.eessi.service.sed.helpers.SedMapperFactory;
 import no.nav.melosys.eessi.service.sed.mapper.SedMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -124,7 +125,11 @@ public class SedService {
     }
 
     private static Optional<Document> finnDokumentVedSedType(List<Document> documents, String sedType) {
-        return documents.stream().filter(d -> sedType.equals(d.getType())).findFirst();
+        return documents.stream().filter(d -> sedType.equals(d.getType())).min(sorterEtterStatus());
+    }
+
+    private static Comparator<? super Document> sorterEtterStatus() {
+        return Comparator.comparing(document -> SedStatus.fraEngelskStatus(document.getStatus()));
     }
 
     private Optional<BUC> finnAapenEksisterendeSak(List<FagsakRinasakKobling> eksisterendeSaker) throws IntegrationException {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import no.nav.melosys.eessi.controller.dto.OpprettSedDto;
 import no.nav.melosys.eessi.controller.dto.Periode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
@@ -115,27 +116,40 @@ public class SedServiceTest {
         when(saksrelasjonService.finnVedGsakSaksnummerOgBucType(eq(gsakSaksnummer), eq(BucType.LA_BUC_04)))
                 .thenReturn(Collections.singletonList(fagsakRinasakKobling));
 
-        String documentId = "docid12314";
         BUC buc = new BUC();
         buc.setId(RINA_ID);
         buc.setStatus("open");
-        Document document = new Document();
-        document.setStatus("open");
-        document.setId(documentId);
-        document.setType(SedType.A009.name());
-        buc.setDocuments(Collections.singletonList(document));
 
-        Action action = new Action();
-        action.setDocumentId(documentId);
-        action.setOperation("update");
-        buc.setActions(Collections.singletonList(action));
+        String emptyDocumentId = "docid12314";
+        Document emptyDocument = new Document();
+        emptyDocument.setStatus("empty");
+        emptyDocument.setId(emptyDocumentId);
+        emptyDocument.setType(SedType.A009.name());
+
+        String sentDocumentId = "docid321";
+        Document sentDocument = new Document();
+        sentDocument.setStatus("sent");
+        sentDocument.setId(sentDocumentId);
+        sentDocument.setType(SedType.A009.name());
+
+        buc.setDocuments(List.of(emptyDocument, sentDocument));
+
+        Action emptyDocAction = new Action();
+        emptyDocAction.setDocumentId(emptyDocumentId);
+        emptyDocAction.setOperation("update");
+
+        Action sentDocAction = new Action();
+        sentDocAction.setDocumentId(sentDocumentId);
+        sentDocAction.setOperation("update");
+
+        buc.setActions(List.of(emptyDocAction, sentDocAction));
 
         when(euxService.hentBuc(eq(RINA_ID)))
                 .thenReturn(buc);
 
         sendSedService.opprettBucOgSed(sedDataDto, null, BucType.LA_BUC_04, true);
 
-        verify(euxService).oppdaterSed(eq(RINA_ID), eq(documentId), any(SED.class));
+        verify(euxService).oppdaterSed(eq(RINA_ID), eq(sentDocumentId), any(SED.class));
         verify(euxService, never()).opprettBucOgSed(any(), any(), any(), any(), any());
         verify(euxService).sendSed(anyString(), anyString());
     }


### PR DESCRIPTION
Sorterer seder etter status når vi skal finne tidl. sed med type.
Sedene sorteres etter rekkefølge på enum-verdier i SedStatus.