### PR TITLE
Integrerer mot SAF for å kunne hente ut tilleggsopplysninger for journalpost

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/SafConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/SafConsumer.java
@@ -1,0 +1,49 @@
+package no.nav.melosys.eessi.integration.saf;
+
+import java.util.Optional;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.melosys.eessi.integration.RestConsumer;
+import no.nav.melosys.eessi.integration.saf.dto.GraphQLResponse;
+import no.nav.melosys.eessi.models.exception.IntegrationException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class SafConsumer implements RestConsumer {
+
+    private final RestTemplate restTemplate;
+
+    private static final String QUERY = "{query: journalpost(journalpostId: \"%s\") {tilleggsopplysninger{nokkel verdi}}}";
+
+    public SafConsumer(RestTemplate safRestTemplate) {
+        this.restTemplate = safRestTemplate;
+    }
+
+    public Optional<String> hentRinasakForJournalpost(String journalpostID) throws IntegrationException {
+
+        HttpEntity httpEntity = new HttpEntity(new GraphQLWrapper(String.format(QUERY, journalpostID), null), defaultHeaders());
+        GraphQLResponse response = restTemplate.exchange("/graphql", HttpMethod.POST, httpEntity, GraphQLResponse.class).getBody();
+
+        if (response == null) {
+            log.info("Mottatt null-response fra SAF");
+            return Optional.empty();
+        } else if (response.harFeil()) {
+            throw new IntegrationException("Feil ved integrasjon mot saf. Feilmeldinger: " + response.lagErrorString());
+        }
+
+        return response.getData().getQuery().hentRinaSakId();
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class GraphQLWrapper {
+        private String query;
+        private String variables;
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/SafConsumerProducer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/SafConsumerProducer.java
@@ -1,0 +1,28 @@
+package no.nav.melosys.eessi.integration.saf;
+
+import no.nav.melosys.eessi.security.SystemContextClientRequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Configuration
+public class SafConsumerProducer {
+
+    private final String uri;
+
+    public SafConsumerProducer(@Value("${melosys.integrations.saf-url}") String uri) {
+        this.uri = uri;
+    }
+
+    @Bean
+    public RestTemplate safRestTemplate(SystemContextClientRequestInterceptor interceptor) {
+        return new RestTemplateBuilder()
+                .uriTemplateHandler(new DefaultUriBuilderFactory(uri))
+                .interceptors(interceptor)
+                .build();
+    }
+
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/GraphQLError.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/GraphQLError.java
@@ -1,0 +1,8 @@
+package no.nav.melosys.eessi.integration.saf.dto;
+
+import lombok.Data;
+
+@Data
+public class GraphQLError {
+    private String message;
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/GraphQLQueryData.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/GraphQLQueryData.java
@@ -1,0 +1,8 @@
+package no.nav.melosys.eessi.integration.saf.dto;
+
+import lombok.Data;
+
+@Data
+public class GraphQLQueryData {
+    private SafQueryData query;
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/GraphQLResponse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/GraphQLResponse.java
@@ -1,0 +1,21 @@
+package no.nav.melosys.eessi.integration.saf.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.Data;
+import org.springframework.util.CollectionUtils;
+
+@Data
+public class GraphQLResponse {
+    private List<GraphQLError> errors;
+    private GraphQLQueryData data;
+
+    public boolean harFeil() {
+        return !CollectionUtils.isEmpty(errors) || data == null;
+    }
+
+    public String lagErrorString() {
+        return errors.stream().map(GraphQLError::getMessage).collect(Collectors.joining("\n"));
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/SafQueryData.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/SafQueryData.java
@@ -1,0 +1,20 @@
+package no.nav.melosys.eessi.integration.saf.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import lombok.Data;
+
+@Data
+public class SafQueryData {
+
+    private List<Tilleggsopplysning> tilleggsopplysninger = new ArrayList<>();
+
+    public Optional<String> hentRinaSakId() {
+        return tilleggsopplysninger.stream()
+                .filter(t -> "rinaSakId".equals(t.getNokkel()))
+                .map(Tilleggsopplysning::getVerdi)
+                .findFirst();
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/Tilleggsopplysning.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/saf/dto/Tilleggsopplysning.java
@@ -1,0 +1,13 @@
+package no.nav.melosys.eessi.integration.saf.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Tilleggsopplysning {
+    private String nokkel;
+    private String verdi;
+}

--- a/melosys-eessi-app/src/main/resources/application-local.properties
+++ b/melosys-eessi-app/src/main/resources/application-local.properties
@@ -14,6 +14,7 @@ JOURNALPOSTAPI_URL=https://dokarkiv-t8.nais.preprod.local/rest/journalpostapi/v1
 RINA_HOST_URL=https://rina-oppl-utv004.adeo.no
 OPPGAVE_URL=https://oppgave-t8.nais.preprod.local/api/v1
 EUXCASESTORE_URL=https://eux-case-store.nais.preprod.local
+SAF_URL=https://saf-t8.nais.preprod.local
 ISSO_URL=https://isso-t.adeo.no/isso/oauth2
 ISSO_ACCEPTED_AUDIENCE=melosys-localhost,ida-t
 

--- a/melosys-eessi-app/src/main/resources/application.yml
+++ b/melosys-eessi-app/src/main/resources/application.yml
@@ -49,6 +49,7 @@ melosys:
     rina-host-url: ${RINA_HOST_URL}
     journalpostapi-url: ${JOURNALPOSTAPI_URL}
     eux-case-store-url: ${EUXCASESTORE_URL}
+    saf-url: ${SAF_URL}
 
     dokkat:
       typeid-url: ${DOKKATTYPEID_URL}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/saf/SafConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/saf/SafConsumerTest.java
@@ -1,0 +1,74 @@
+package no.nav.melosys.eessi.integration.saf;
+
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.melosys.eessi.models.exception.IntegrationException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+public class SafConsumerTest {
+
+    private MockRestServiceServer server;
+    private RestTemplate restTemplate = new RestTemplate();
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private SafConsumer safConsumer;
+
+    private final String journalpostID = "143432657";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        server = MockRestServiceServer.createServer(restTemplate);
+        safConsumer = new SafConsumer(restTemplate);
+    }
+
+    @Test
+    public void hentTilleggsopplysning_ingenFeil_returnererTilleggsopplynsning() throws Exception {
+        final String rinaSaksnummer = "64789743";
+        server.expect(requestTo("/graphql")).andRespond(withSuccess(hentOkRespons(), MediaType.APPLICATION_JSON));
+
+        Optional<String> optionalRinasaksnummer = safConsumer.hentRinasakForJournalpost(journalpostID);
+        assertThat(optionalRinasaksnummer).isPresent();
+        assertThat(optionalRinasaksnummer.get()).isEqualTo(rinaSaksnummer);
+    }
+
+    @Test
+    public void hentTilleggsopplysning_medFeil_kasterException() throws Exception {
+        server.expect(requestTo("/graphql")).andRespond(withSuccess(hentErrorRespons(), MediaType.APPLICATION_JSON));
+
+        expectedException.expect(IntegrationException.class);
+        expectedException.expectMessage("feil1\nfeil2");
+
+        safConsumer.hentRinasakForJournalpost("1231");
+    }
+
+    private String hentErrorRespons() throws Exception {
+        return hentFil("mock/saf-err.json");
+    }
+
+    private String hentOkRespons() throws Exception {
+        return hentFil("mock/saf.json");
+    }
+
+    private String hentFil(String filnavn) throws Exception {
+        Path path = Paths.get(this.getClass().getClassLoader().getResource(filnavn).toURI());
+        return Files.readString(path);
+    }
+}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingServiceTest.java
@@ -2,11 +2,13 @@ package no.nav.melosys.eessi.service.journalpostkobling;
 
 import java.util.Collections;
 import java.util.Optional;
+
 import io.github.benas.randombeans.api.EnhancedRandom;
 import no.nav.melosys.eessi.EnhancedRandomCreator;
 import no.nav.melosys.eessi.controller.dto.SedStatus;
 import no.nav.melosys.eessi.integration.eux.case_store.CaseStoreConsumer;
 import no.nav.melosys.eessi.integration.eux.case_store.CaseStoreDto;
+import no.nav.melosys.eessi.integration.saf.SafConsumer;
 import no.nav.melosys.eessi.kafka.producers.model.MelosysEessiMelding;
 import no.nav.melosys.eessi.models.JournalpostSedKobling;
 import no.nav.melosys.eessi.models.buc.BUC;
@@ -21,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -36,6 +39,8 @@ public class JournalpostSedKoblingServiceTest {
     private EuxService euxService;
     @Mock
     private SaksrelasjonService saksrelasjonService;
+    @Mock
+    private SafConsumer safConsumer;
 
     private JournalpostSedKoblingService journalpostSedKoblingService;
 
@@ -45,8 +50,8 @@ public class JournalpostSedKoblingServiceTest {
     @Before
     public void setup() {
         journalpostSedKoblingService = new JournalpostSedKoblingService(
-                journalpostSedKoblingRepository, caseStoreConsumer, euxService, saksrelasjonService
-        );
+                journalpostSedKoblingRepository, caseStoreConsumer, euxService, saksrelasjonService,
+                safConsumer);
 
         sed = new SED();
         sed.setNav(new Nav());

--- a/melosys-eessi-app/src/test/resources/mock/saf-err.json
+++ b/melosys-eessi-app/src/test/resources/mock/saf-err.json
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "message": "feil1",
+      "exception": "NullPointerException"
+    },
+    {
+      "message": "feil2",
+      "exception": "NullPointerException"
+    }
+  ],
+  "data": {
+    "query": null
+  }
+}

--- a/melosys-eessi-app/src/test/resources/mock/saf.json
+++ b/melosys-eessi-app/src/test/resources/mock/saf.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "query": {
+      "tilleggsopplysninger": [
+        {
+          "nokkel": "rinaSakId",
+          "verdi": "64789743"
+        },
+        {
+          "nokkel": "rinaDokumentId",
+          "verdi": "e9338ef8d2e64c55abfaa7718cbd92d9"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Grunnet at eux-case-store bare holder på informasjon for siste journalpost som har kommet inn på en sak, integrerer vi mot SAF for å kunne se på tilleggsopplysninger til en journalpost - hvor EESSI-applikasjonene alltid lagrer rinaSakId på.