### PR TITLE
Håndter at melosys ikke er EESSI-ready

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -1,5 +1,6 @@
 package no.nav.melosys.eessi.service.eux;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -9,6 +10,7 @@ import no.nav.melosys.eessi.integration.eux.rina_api.EuxConsumer;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.TilegnetBuc;
 import no.nav.melosys.eessi.metrikker.BucMetrikker;
+import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -34,14 +36,17 @@ public class EuxService {
     private final BucMetrikker bucMetrikker;
 
     private final String rinaHostUrl;
+    private boolean featureToggleEessiReady;
 
     @Autowired
     public EuxService(EuxConsumer euxConsumer,
-            BucMetrikker bucMetrikker,
-            @Value("${melosys.integrations.rina-host-url}") String rinaHostUrl) {
+                      BucMetrikker bucMetrikker,
+                      @Value("${melosys.integrations.rina-host-url}") String rinaHostUrl,
+                      @Value("${melosys.feature.eessiready:false}") String featureToggleEessiReady) {
         this.euxConsumer = euxConsumer;
         this.bucMetrikker = bucMetrikker;
         this.rinaHostUrl = rinaHostUrl;
+        this.featureToggleEessiReady = Boolean.parseBoolean(featureToggleEessiReady);
     }
 
     public void slettBuC(String rinaSaksnummer) throws IntegrationException {
@@ -75,6 +80,10 @@ public class EuxService {
     public List<Institusjon> hentMottakerinstitusjoner(final String bucType, final String landkode)
             throws IntegrationException {
 
+        if (!norgeErPåkoblet(bucType)) {
+            return Collections.emptyList();
+        }
+
         return euxConsumer.hentInstitusjoner(bucType, null).stream()
                 .peek(i -> i.setLandkode(LandkodeMapper.mapTilNavLandkode(i.getLandkode())))
                 .filter(i -> filtrerPåLandkode(i, landkode))
@@ -83,6 +92,15 @@ public class EuxService {
                                 COUNTERPARTY.equals(tilegnetBuc.getInstitusjonsrolle()))
                         .anyMatch(TilegnetBuc::erEessiKlar))
                 .collect(Collectors.toList());
+    }
+
+    private boolean norgeErPåkoblet(String bucType) {
+        BucType bucTypeEnum = BucType.valueOf(bucType);
+        if (featureToggleEessiReady && bucTypeEnum.erLovvalgBuc()) {
+            return bucTypeEnum == BucType.LA_BUC_01 || bucTypeEnum == BucType.LA_BUC_04;
+        }
+
+        return true;
     }
 
     private boolean filtrerPåLandkode(Institusjon institusjon, String landkode) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxTokenContextService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxTokenContextService.java
@@ -12,7 +12,8 @@ public class EuxTokenContextService extends EuxService {
 
     public EuxTokenContextService(@Qualifier("tokenContext") EuxConsumer euxConsumer,
                                   BucMetrikker bucMetrikker,
-                                  @Value("${melosys.integrations.rina-host-url}") String rinaHostUrl) {
-        super(euxConsumer, bucMetrikker, rinaHostUrl);
+                                  @Value("${melosys.integrations.rina-host-url}") String rinaHostUrl,
+                                  @Value("${melosys.feature.eessiready:false}") String featureToggleEessiReady) {
+        super(euxConsumer, bucMetrikker, rinaHostUrl, featureToggleEessiReady);
     }
 }

--- a/melosys-eessi-app/src/main/resources/application.yml
+++ b/melosys-eessi-app/src/main/resources/application.yml
@@ -27,6 +27,8 @@ spring:
       reconnect.backoff.ms: 1000
 
 melosys:
+  feature:
+    eessiready: ${FEATURE_EESSIREADY:false}
   kafka:
     consumer:
       mottatt:

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
@@ -49,7 +49,7 @@ public class EuxServiceTest {
     @Before
     public void setup() throws IOException, IntegrationException {
         final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        euxService = new EuxService(euxConsumer, bucMetrikker, RINA_MOCK_URL);
+        euxService = new EuxService(euxConsumer, bucMetrikker, RINA_MOCK_URL, "false");
 
         when(euxConsumer.opprettBucOgSed(anyString(), anyString(), any()))
                 .thenReturn(ImmutableMap.of(
@@ -178,7 +178,7 @@ public class EuxServiceTest {
 
     @Test
     public void hentMottakerinstitusjoner_sBuc18LandSverige_forventIngenInstitusjoner() throws IntegrationException {
-        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("S_BUC_18", "SE");
+        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("S_BUC_24", "SE");
         assertThat(institusjoner).isEmpty();
     }
 
@@ -200,6 +200,15 @@ public class EuxServiceTest {
         Institusjon institusjon = institusjoner.get(0);
         assertThat(institusjon.getAkronym()).isEqualTo("FK EL-TITTEI");
         assertThat(institusjon.getLandkode()).isEqualTo("GR");
+    }
+
+    @Test
+    public void hentMottakerinstitusjoner_laBuc02LandGRNorgeIkkePåkoblet_forventTomListe() throws IntegrationException {
+        euxService = new EuxService(euxConsumer, bucMetrikker, "url", "true");
+        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("LA_BUC_02", "GR");
+        assertThat(institusjoner).hasSize(0);
+
+        verify(euxConsumer, never()).hentInstitusjoner(any(), any());
     }
 
     @Test


### PR DESCRIPTION
Legger til variabel for feature-toggling av Norge sin eessi-ready status på enkelte BUC-er. Det skal returneres en tom liste ved henting av mottakinstitusjoner når Norge ikke er påkoblet den aktuelle BUCen