### PR TITLE
Fikser integrasjon mot eux for å legge til vedlegg på en SED

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -61,7 +61,8 @@ public class EuxService {
         String dokumentID = euxConsumer.opprettSed(rinaSaksnummer, sed);
 
         if (ArrayUtils.isNotEmpty(vedlegg)) {
-            euxConsumer.leggTilVedlegg(rinaSaksnummer, dokumentID, FILTYPE_PDF, vedlegg);
+            String vedleggID = euxConsumer.leggTilVedlegg(rinaSaksnummer, dokumentID, FILTYPE_PDF, vedlegg);
+            log.info("Lagt til vedlegg med ID {} i rinasak {}", vedleggID, rinaSaksnummer);
         }
 
         bucMetrikker.bucOpprettet(bucType.name());

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
@@ -374,10 +374,10 @@ public class EuxConsumerTest {
 
         String forventetRetur = "{}";
 
-        server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId + "/vedlegg?Filtype=" + filtype))
+        server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId + "/vedlegg?Filtype=" + filtype + "&synkron=true"))
                 .andRespond(withSuccess(forventetRetur, MediaType.APPLICATION_JSON));
 
-        String resultat = euxConsumer.leggTilVedlegg(id, dokumentId, filtype, "vedlegg");
+        String resultat = euxConsumer.leggTilVedlegg(id, dokumentId, filtype, "vedlegg".getBytes());
         assertThat(resultat).isEqualTo(forventetRetur);
     }
 


### PR DESCRIPTION
Integrasjon mot eux for å legge til vedlegg var litt vel gammel, og melosys hadde egentlig aldri brukt den. 
Etter en titt på eux-rina-api så jeg at tjenesten krevde multipart_form_data som content_type. 

Fikser feil ved videresending av søknad.