### PR TITLE
Melosys 3744  vedlegg filnavn sed

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
@@ -12,7 +12,7 @@ import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.controller.dto.SedGrunnlagDto;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.SedType;
-import no.nav.melosys.eessi.models.Vedlegg;
+import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.exception.MappingException;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
@@ -54,7 +54,7 @@ public class BucController {
             @PathVariable("bucType") BucType bucType,
             @RequestParam(value = "sendAutomatisk") boolean sendAutomatisk
     ) throws IntegrationException, NotFoundException, MappingException, IOException, ValidationException {
-        return sedService.opprettBucOgSed(sedDataDto, vedlegg != null ? new Vedlegg(vedlegg.getName(), vedlegg.getBytes()) : null, bucType, sendAutomatisk);
+        return sedService.opprettBucOgSed(sedDataDto, vedlegg != null ? new SedVedlegg(vedlegg.getOriginalFilename(), vedlegg.getBytes()) : null, bucType, sendAutomatisk);
     }
 
     @ApiOperation(value = "Oppretter og sender en sed på en eksisterende buc")

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
@@ -12,6 +12,7 @@ import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.controller.dto.SedGrunnlagDto;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.SedType;
+import no.nav.melosys.eessi.models.Vedlegg;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.exception.MappingException;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
@@ -53,7 +54,7 @@ public class BucController {
             @PathVariable("bucType") BucType bucType,
             @RequestParam(value = "sendAutomatisk") boolean sendAutomatisk
     ) throws IntegrationException, NotFoundException, MappingException, IOException, ValidationException {
-        return sedService.opprettBucOgSed(sedDataDto, vedlegg != null ? vedlegg.getBytes() : null, bucType, sendAutomatisk);
+        return sedService.opprettBucOgSed(sedDataDto, vedlegg != null ? new Vedlegg(vedlegg.getName(), vedlegg.getBytes()) : null, bucType, sendAutomatisk);
     }
 
     @ApiOperation(value = "Oppretter og sender en sed på en eksisterende buc")

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
@@ -1,5 +1,7 @@
 package no.nav.melosys.eessi.integration.eux.rina_api;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -12,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.integration.RestConsumer;
 import no.nav.melosys.eessi.integration.UUIDGenerator;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
-import no.nav.melosys.eessi.models.Vedlegg;
+import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -249,7 +251,7 @@ public class EuxConsumer implements RestConsumer, UUIDGenerator {
      * @return ukjent
      */
     public String leggTilVedlegg(String rinaSaksnummer, String dokumentId, String filType,
-                                 Vedlegg vedlegg) throws IntegrationException {
+                                 SedVedlegg vedlegg) throws IntegrationException {
         log.info("Legger til vedlegg på sak {} og dokument {}", rinaSaksnummer, dokumentId);
 
         HttpHeaders headers = new HttpHeaders();
@@ -269,7 +271,7 @@ public class EuxConsumer implements RestConsumer, UUIDGenerator {
         String uri = UriComponentsBuilder
                 .fromPath(String.format(VEDLEGG_PATH, rinaSaksnummer, dokumentId))
                 .queryParam("Filtype", filType)
-                .queryParam("Filnavn", vedlegg.getFilnavn())
+                .queryParam("Filnavn", URLEncoder.encode(vedlegg.getFilnavn(), StandardCharsets.UTF_8))
                 .queryParam("synkron", Boolean.TRUE)
                 .toUriString();
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.integration.RestConsumer;
 import no.nav.melosys.eessi.integration.UUIDGenerator;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
+import no.nav.melosys.eessi.models.Vedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -248,17 +249,17 @@ public class EuxConsumer implements RestConsumer, UUIDGenerator {
      * @return ukjent
      */
     public String leggTilVedlegg(String rinaSaksnummer, String dokumentId, String filType,
-                                 byte[] vedlegg) throws IntegrationException {
+                                 Vedlegg vedlegg) throws IntegrationException {
         log.info("Legger til vedlegg på sak {} og dokument {}", rinaSaksnummer, dokumentId);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-        ByteArrayResource document = new ByteArrayResource(vedlegg) {
+        ByteArrayResource document = new ByteArrayResource(vedlegg.getInnhold()) {
             @Override
             public String getFilename() {
-                return "file";
+                return vedlegg.getFilnavn();
             }
         };
 
@@ -268,7 +269,9 @@ public class EuxConsumer implements RestConsumer, UUIDGenerator {
         String uri = UriComponentsBuilder
                 .fromPath(String.format(VEDLEGG_PATH, rinaSaksnummer, dokumentId))
                 .queryParam("Filtype", filType)
-                .queryParam("synkron", Boolean.TRUE).toUriString();
+                .queryParam("Filnavn", vedlegg.getFilnavn())
+                .queryParam("synkron", Boolean.TRUE)
+                .toUriString();
 
         return exchange(uri, HttpMethod.POST, new HttpEntity<>(multipartBody, headers),
                 new ParameterizedTypeReference<String>() {});

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/SedVedlegg.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/SedVedlegg.java
@@ -3,7 +3,7 @@ package no.nav.melosys.eessi.models;
 import lombok.Value;
 
 @Value
-public class Vedlegg {
+public class SedVedlegg {
     private final String filnavn;
     private final byte[] innhold;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/Vedlegg.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/Vedlegg.java
@@ -1,0 +1,9 @@
+package no.nav.melosys.eessi.models;
+
+import lombok.Value;
+
+@Value
+public class Vedlegg {
+    private final String filnavn;
+    private final byte[] innhold;
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -11,13 +11,13 @@ import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.TilegnetBuc;
 import no.nav.melosys.eessi.metrikker.BucMetrikker;
 import no.nav.melosys.eessi.models.BucType;
+import no.nav.melosys.eessi.models.Vedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
 import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
-import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
@@ -54,13 +54,13 @@ public class EuxService {
         euxConsumer.slettBuC(rinaSaksnummer);
     }
 
-    public OpprettBucOgSedResponse opprettBucOgSed(BucType bucType, Collection<String> mottakere, SED sed, byte[] vedlegg) throws IntegrationException {
+    public OpprettBucOgSedResponse opprettBucOgSed(BucType bucType, Collection<String> mottakere, SED sed, Vedlegg vedlegg) throws IntegrationException {
 
         String rinaSaksnummer = euxConsumer.opprettBuC(bucType.name());
         euxConsumer.settMottakere(rinaSaksnummer, mottakere);
         String dokumentID = euxConsumer.opprettSed(rinaSaksnummer, sed);
 
-        if (ArrayUtils.isNotEmpty(vedlegg)) {
+        if (vedlegg != null) {
             String vedleggID = euxConsumer.leggTilVedlegg(rinaSaksnummer, dokumentID, FILTYPE_PDF, vedlegg);
             log.info("Lagt til vedlegg med ID {} i rinasak {}", vedleggID, rinaSaksnummer);
         }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -11,7 +11,7 @@ import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.TilegnetBuc;
 import no.nav.melosys.eessi.metrikker.BucMetrikker;
 import no.nav.melosys.eessi.models.BucType;
-import no.nav.melosys.eessi.models.Vedlegg;
+import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -54,7 +54,7 @@ public class EuxService {
         euxConsumer.slettBuC(rinaSaksnummer);
     }
 
-    public OpprettBucOgSedResponse opprettBucOgSed(BucType bucType, Collection<String> mottakere, SED sed, Vedlegg vedlegg) throws IntegrationException {
+    public OpprettBucOgSedResponse opprettBucOgSed(BucType bucType, Collection<String> mottakere, SED sed, SedVedlegg vedlegg) throws IntegrationException {
 
         String rinaSaksnummer = euxConsumer.opprettBuC(bucType.name());
         euxConsumer.settMottakere(rinaSaksnummer, mottakere);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
@@ -10,7 +10,7 @@ import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.models.SedType;
-import no.nav.melosys.eessi.models.Vedlegg;
+import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.buc.Document;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -41,7 +41,7 @@ public class SedService {
         this.saksrelasjonService = saksrelasjonService;
     }
 
-    public OpprettSedDto opprettBucOgSed(SedDataDto sedDataDto, Vedlegg vedlegg, BucType bucType, boolean sendAutomatisk)
+    public OpprettSedDto opprettBucOgSed(SedDataDto sedDataDto, SedVedlegg vedlegg, BucType bucType, boolean sendAutomatisk)
             throws MappingException, IntegrationException, NotFoundException, ValidationException {
 
         Long gsakSaksnummer = hentGsakSaksnummer(sedDataDto);
@@ -108,7 +108,7 @@ public class SedService {
         euxService.opprettOgSendSed(sed, rinaSaksnummer);
     }
 
-    private OpprettBucOgSedResponse opprettEllerOppdaterBucOgSed(SED sed, Vedlegg vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder) throws IntegrationException {
+    private OpprettBucOgSedResponse opprettEllerOppdaterBucOgSed(SED sed, SedVedlegg vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder) throws IntegrationException {
 
         if (bucType.meddelerLovvalg()) {
             Optional<BUC> eksisterendeSak = finnAapenEksisterendeSak(
@@ -143,7 +143,7 @@ public class SedService {
         return Optional.empty();
     }
 
-    private OpprettBucOgSedResponse opprettOgLagreSaksrelasjon(SED sed, Vedlegg vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder)
+    private OpprettBucOgSedResponse opprettOgLagreSaksrelasjon(SED sed, SedVedlegg vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder)
             throws IntegrationException {
         OpprettBucOgSedResponse opprettBucOgSedResponse = euxService.opprettBucOgSed(bucType, mottakerIder, sed, vedlegg);
         saksrelasjonService.lagreKobling(gsakSaksnummer, opprettBucOgSedResponse.getRinaSaksnummer(), bucType);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
@@ -10,6 +10,7 @@ import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.models.SedType;
+import no.nav.melosys.eessi.models.Vedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.buc.Document;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -40,7 +41,7 @@ public class SedService {
         this.saksrelasjonService = saksrelasjonService;
     }
 
-    public OpprettSedDto opprettBucOgSed(SedDataDto sedDataDto, byte[] vedlegg, BucType bucType, boolean sendAutomatisk)
+    public OpprettSedDto opprettBucOgSed(SedDataDto sedDataDto, Vedlegg vedlegg, BucType bucType, boolean sendAutomatisk)
             throws MappingException, IntegrationException, NotFoundException, ValidationException {
 
         Long gsakSaksnummer = hentGsakSaksnummer(sedDataDto);
@@ -107,7 +108,7 @@ public class SedService {
         euxService.opprettOgSendSed(sed, rinaSaksnummer);
     }
 
-    private OpprettBucOgSedResponse opprettEllerOppdaterBucOgSed(SED sed, byte[] vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder) throws IntegrationException {
+    private OpprettBucOgSedResponse opprettEllerOppdaterBucOgSed(SED sed, Vedlegg vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder) throws IntegrationException {
 
         if (bucType.meddelerLovvalg()) {
             Optional<BUC> eksisterendeSak = finnAapenEksisterendeSak(
@@ -142,7 +143,7 @@ public class SedService {
         return Optional.empty();
     }
 
-    private OpprettBucOgSedResponse opprettOgLagreSaksrelasjon(SED sed, byte[] vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder)
+    private OpprettBucOgSedResponse opprettOgLagreSaksrelasjon(SED sed, Vedlegg vedlegg, BucType bucType, Long gsakSaksnummer, List<String> mottakerIder)
             throws IntegrationException {
         OpprettBucOgSedResponse opprettBucOgSedResponse = euxService.opprettBucOgSed(bucType, mottakerIder, sed, vedlegg);
         saksrelasjonService.lagreKobling(gsakSaksnummer, opprettBucOgSedResponse.getRinaSaksnummer(), bucType);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
 import no.nav.melosys.eessi.models.SedType;
+import no.nav.melosys.eessi.models.Vedlegg;
 import no.nav.melosys.eessi.models.buc.*;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -368,16 +369,18 @@ public class EuxConsumerTest {
 
     @Test
     public void leggTilVedlegg_forventId() throws Exception {
-        String id = "123";
-        String dokumentId = "123321";
-        String filtype = "virus.exe";
+        final String id = "123";
+        final String dokumentId = "123321";
+        final String filtype = "virus.exe";
+        final String filNavn = "filnavnn123";
+
 
         String forventetRetur = "{}";
 
-        server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId + "/vedlegg?Filtype=" + filtype + "&synkron=true"))
+        server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId + "/vedlegg?Filtype=" + filtype + "&Filnavn=" + filNavn + "&synkron=true"))
                 .andRespond(withSuccess(forventetRetur, MediaType.APPLICATION_JSON));
 
-        String resultat = euxConsumer.leggTilVedlegg(id, dokumentId, filtype, "vedlegg".getBytes());
+        String resultat = euxConsumer.leggTilVedlegg(id, dokumentId, filtype, new Vedlegg(filNavn, "vedlegg".getBytes()));
         assertThat(resultat).isEqualTo(forventetRetur);
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
 import no.nav.melosys.eessi.models.SedType;
-import no.nav.melosys.eessi.models.Vedlegg;
+import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.buc.*;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
@@ -372,15 +372,15 @@ public class EuxConsumerTest {
         final String id = "123";
         final String dokumentId = "123321";
         final String filtype = "virus.exe";
-        final String filNavn = "filnavnn123";
-
+        final String filNavn = "filnavn123";
 
         String forventetRetur = "{}";
 
-        server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId + "/vedlegg?Filtype=" + filtype + "&Filnavn=" + filNavn + "&synkron=true"))
+        server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId + "/vedlegg?Filtype=" + filtype
+                + "&Filnavn=" + filNavn + "&synkron=true"))
                 .andRespond(withSuccess(forventetRetur, MediaType.APPLICATION_JSON));
 
-        String resultat = euxConsumer.leggTilVedlegg(id, dokumentId, filtype, new Vedlegg(filNavn, "vedlegg".getBytes()));
+        String resultat = euxConsumer.leggTilVedlegg(id, dokumentId, filtype, new SedVedlegg(filNavn, "vedlegg".getBytes()));
         assertThat(resultat).isEqualTo(forventetRetur);
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
@@ -374,7 +374,7 @@ public class EuxConsumerTest {
         final String filtype = "virus.exe";
         final String filNavn = "filnavn123";
 
-        String forventetRetur = "{}";
+        final String forventetRetur = "546327ghrjek";
 
         server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId + "/vedlegg?Filtype=" + filtype
                 + "&Filnavn=" + filNavn + "&synkron=true"))

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
@@ -14,7 +14,7 @@ import no.nav.melosys.eessi.integration.eux.rina_api.EuxConsumer;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
 import no.nav.melosys.eessi.metrikker.BucMetrikker;
 import no.nav.melosys.eessi.models.BucType;
-import no.nav.melosys.eessi.models.Vedlegg;
+import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.buc.Conversation;
 import no.nav.melosys.eessi.models.buc.Document;
@@ -109,11 +109,11 @@ public class EuxServiceTest {
         Collection<String> mottakere = List.of("SE:123");
         SED sed = new SED();
 
-        OpprettBucOgSedResponse opprettBucOgSedResponse = euxService.opprettBucOgSed(bucType, mottakere, sed, new Vedlegg("filen min", "pdf".getBytes()));
+        OpprettBucOgSedResponse opprettBucOgSedResponse = euxService.opprettBucOgSed(bucType, mottakere, sed, new SedVedlegg("filen min", "pdf".getBytes()));
 
         verify(euxConsumer).opprettBuC(eq(bucType.name()));
         verify(euxConsumer).opprettSed(eq(opprettetBucID), eq(sed));
-        verify(euxConsumer).leggTilVedlegg(eq(opprettetBucID), eq(opprettetSedID), eq("pdf"), any(Vedlegg.class));
+        verify(euxConsumer).leggTilVedlegg(eq(opprettetBucID), eq(opprettetSedID), eq("pdf"), any(SedVedlegg.class));
 
         assertThat(opprettBucOgSedResponse.getRinaSaksnummer()).isEqualTo(opprettetBucID);
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
@@ -14,6 +14,7 @@ import no.nav.melosys.eessi.integration.eux.rina_api.EuxConsumer;
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.Institusjon;
 import no.nav.melosys.eessi.metrikker.BucMetrikker;
 import no.nav.melosys.eessi.models.BucType;
+import no.nav.melosys.eessi.models.Vedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.buc.Conversation;
 import no.nav.melosys.eessi.models.buc.Document;
@@ -108,11 +109,11 @@ public class EuxServiceTest {
         Collection<String> mottakere = List.of("SE:123");
         SED sed = new SED();
 
-        OpprettBucOgSedResponse opprettBucOgSedResponse = euxService.opprettBucOgSed(bucType, mottakere, sed, new byte[]{1,1});
+        OpprettBucOgSedResponse opprettBucOgSedResponse = euxService.opprettBucOgSed(bucType, mottakere, sed, new Vedlegg("filen min", "pdf".getBytes()));
 
         verify(euxConsumer).opprettBuC(eq(bucType.name()));
         verify(euxConsumer).opprettSed(eq(opprettetBucID), eq(sed));
-        verify(euxConsumer).leggTilVedlegg(eq(opprettetBucID), eq(opprettetSedID), eq("pdf"), any(byte[].class));
+        verify(euxConsumer).leggTilVedlegg(eq(opprettetBucID), eq(opprettetSedID), eq("pdf"), any(Vedlegg.class));
 
         assertThat(opprettBucOgSedResponse.getRinaSaksnummer()).isEqualTo(opprettetBucID);
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
@@ -14,7 +14,7 @@ import no.nav.melosys.eessi.controller.dto.SvarAnmodningUnntakDto;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.models.SedType;
-import no.nav.melosys.eessi.models.Vedlegg;
+import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.buc.Action;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.buc.Document;
@@ -70,7 +70,7 @@ public class SedServiceTest {
     public void opprettBucOgSed_forventRinacaseId() throws Exception {
         SedDataDto sedData = SedDataStub.getStub();
         final BucType bucType = BucType.LA_BUC_01;
-        final Vedlegg vedlegg = new Vedlegg("tittei", "pdf".getBytes());
+        final SedVedlegg vedlegg = new SedVedlegg("tittei", "pdf".getBytes());
         OpprettSedDto sedDto = sendSedService.opprettBucOgSed(sedData, vedlegg, BucType.LA_BUC_01, true);
         verify(euxService).opprettBucOgSed(eq(bucType), eq(sedData.getMottakerIder()), any(SED.class), eq(vedlegg));
         assertThat(sedDto.getRinaSaksnummer()).isEqualTo(RINA_ID);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
@@ -14,6 +14,7 @@ import no.nav.melosys.eessi.controller.dto.SvarAnmodningUnntakDto;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.models.SedType;
+import no.nav.melosys.eessi.models.Vedlegg;
 import no.nav.melosys.eessi.models.buc.Action;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.buc.Document;
@@ -30,8 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -54,9 +53,6 @@ public class SedServiceTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    @Captor
-    public ArgumentCaptor<SED> sedArgumentCaptor;
-
     private final String RINA_ID = "aabbcc";
 
     @Before
@@ -73,7 +69,10 @@ public class SedServiceTest {
     @Test
     public void opprettBucOgSed_forventRinacaseId() throws Exception {
         SedDataDto sedData = SedDataStub.getStub();
-        OpprettSedDto sedDto = sendSedService.opprettBucOgSed(sedData, null, BucType.LA_BUC_01, true);
+        final BucType bucType = BucType.LA_BUC_01;
+        final Vedlegg vedlegg = new Vedlegg("tittei", "pdf".getBytes());
+        OpprettSedDto sedDto = sendSedService.opprettBucOgSed(sedData, vedlegg, BucType.LA_BUC_01, true);
+        verify(euxService).opprettBucOgSed(eq(bucType), eq(sedData.getMottakerIder()), any(SED.class), eq(vedlegg));
         assertThat(sedDto.getRinaSaksnummer()).isEqualTo(RINA_ID);
     }
 


### PR DESCRIPTION
Ref https://github.com/navikt/melosys-api/pull/133

Er gjort en liten quick-fix i `EuxConsumer` ved formatering av filnavn. Går ikke helt topp å sende ett vedlegg med æøå - mistenker at det har noe med å gjøre at dette skal sendes med i url-en, og at filnavnet da blir feiltolket av `eux-rina-api`..