### PR TITLE
Melosys 3761  arbeidsgiver lovvalgsland sed

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
@@ -14,8 +14,6 @@ import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
-import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.exception.ValidationException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.service.eux.EuxService;
@@ -53,7 +51,7 @@ public class BucController {
             @RequestPart(value = "vedlegg", required = false) MultipartFile vedlegg,
             @PathVariable("bucType") BucType bucType,
             @RequestParam(value = "sendAutomatisk") boolean sendAutomatisk
-    ) throws IntegrationException, NotFoundException, MappingException, IOException, ValidationException {
+    ) throws IntegrationException, IOException, ValidationException {
         return sedService.opprettBucOgSed(sedDataDto, vedlegg != null ? new SedVedlegg(vedlegg.getOriginalFilename(), vedlegg.getBytes()) : null, bucType, sendAutomatisk);
     }
 
@@ -63,7 +61,7 @@ public class BucController {
             @RequestBody SedDataDto sedDataDto,
             @PathVariable String rinaSaksnummer,
             @PathVariable SedType sedType
-    ) throws IntegrationException, NotFoundException, MappingException {
+    ) throws IntegrationException {
         sedService.sendPåEksisterendeBuc(sedDataDto, rinaSaksnummer, sedType);
     }
 
@@ -78,7 +76,7 @@ public class BucController {
 
     @ApiOperation(value = "Henter sedGrunnlag for gitt sed")
     @GetMapping("/{rinaSaksnummer}/sed/{rinaDokumentId}/grunnlag")
-    public SedGrunnlagDto hentSedGrunnlag(@PathVariable String rinaSaksnummer, @PathVariable String rinaDokumentId) throws IntegrationException, MappingException {
+    public SedGrunnlagDto hentSedGrunnlag(@PathVariable String rinaSaksnummer, @PathVariable String rinaDokumentId) throws IntegrationException {
         SED sed = euxService.hentSed(rinaSaksnummer, rinaDokumentId);
         return SedGrunnlagMapperFactory.getMapper(SedType.valueOf(sed.getSedType())).map(sed);
     }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedDataDto.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedDataDto.java
@@ -1,6 +1,7 @@
 package no.nav.melosys.eessi.controller.dto;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
@@ -10,12 +11,8 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SedDataDto extends SedGrunnlagDto {
-    //Persondok.
     private List<FamilieMedlem> familieMedlem;
     private Bruker bruker;
-
-    //Andre medlemsvariabler
-    private List<Virksomhet> utenlandskeVirksomheter;
 
     //A008 spesifikt
     private String avklartBostedsland;
@@ -32,4 +29,14 @@ public class SedDataDto extends SedGrunnlagDto {
     private SvarAnmodningUnntakDto svarAnmodningUnntak;
 
     private UtpekingAvvisDto utpekingAvvis;
+
+    public Optional<String> finnLovvalgsland() {
+        return getLovvalgsperioder().stream()
+                .map(Lovvalgsperiode::getLovvalgsland)
+                .findFirst();
+    }
+
+    public String finnLovvalgslandDefaultNO() {
+        return finnLovvalgsland().orElse("NO");
+    }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/SedSendtConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/SedSendtConsumer.java
@@ -2,8 +2,6 @@ package no.nav.melosys.eessi.kafka.consumers;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.metrikker.SedMetrikker;
-import no.nav.melosys.eessi.models.exception.IntegrationException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.service.joark.OpprettUtgaaendeJournalpostService;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,8 +32,8 @@ public class SedSendtConsumer {
         try {
             String journalpostId = opprettUtgaaendeJournalpostService.arkiverUtgaaendeSed(sedSendt);
             log.info("Journalpost opprettet med id: {}", journalpostId);
-        } catch (NotFoundException|IntegrationException e) {
-            //Settes pga testing for nå, da gsakSaksnummer ikke alltid vil eksistere, ved feks testing direkte fra rina eller lokalt
+        } catch (Exception e) {
+            //todo: legg inn metrikk/alarm
             log.error("Sed ikke journalført: {}, melding: {}", sedSendt, e.getMessage(), e);
         }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/MappingException.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/MappingException.java
@@ -1,6 +1,6 @@
 package no.nav.melosys.eessi.models.exception;
 
-public class MappingException extends Exception {
+public class MappingException extends RuntimeException {
 
     public MappingException(String message) {
         super(message);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/NotFoundException.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/NotFoundException.java
@@ -1,6 +1,6 @@
 package no.nav.melosys.eessi.models.exception;
 
-public class NotFoundException extends Exception {
+public class NotFoundException extends RuntimeException {
 
     public NotFoundException(String message) {
         super(message);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/SecurityException.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/SecurityException.java
@@ -1,11 +1,6 @@
 package no.nav.melosys.eessi.models.exception;
 
-public class SecurityException extends Exception {
-
-    public SecurityException(String message) {
-        super(message);
-    }
-
+public class SecurityException extends RuntimeException {
     public SecurityException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/ValidationException.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/exception/ValidationException.java
@@ -1,10 +1,6 @@
 package no.nav.melosys.eessi.models.exception;
 
 public class ValidationException extends Exception {
-
-    public ValidationException() {
-    }
-
     public ValidationException(String message) {
         super(message);
     }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/behandling/BehandleSedMottattService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/behandling/BehandleSedMottattService.java
@@ -7,7 +7,6 @@ import no.nav.melosys.eessi.models.SedKontekst;
 import no.nav.melosys.eessi.models.SedMottatt;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
 import no.nav.melosys.eessi.service.eux.EuxService;
@@ -48,7 +47,7 @@ public class BehandleSedMottattService {
         this.oppgaveService = oppgaveService;
     }
 
-    public void behandleSed(SedMottatt sedMottatt) throws NotFoundException, IntegrationException {
+    public void behandleSed(SedMottatt sedMottatt) throws IntegrationException {
         SedKontekst kontekst = sedMottatt.getSedKontekst();
         SED sed = euxService.hentSed(sedMottatt.getSedHendelse().getRinaSakId(),
                 sedMottatt.getSedHendelse().getRinaDokumentId());
@@ -72,7 +71,7 @@ public class BehandleSedMottattService {
         }
     }
 
-    private void identifiserPerson(SedMottatt sedMottatt, SED sed) throws IntegrationException, NotFoundException {
+    private void identifiserPerson(SedMottatt sedMottatt, SED sed) throws IntegrationException {
         log.info("Søker etter person for SED {}", sedMottatt.getSedHendelse().getRinaDokumentId());
         personIdentifiseringService.identifiserPerson(sedMottatt.getSedHendelse(), sed)
                 .ifPresent(s -> sedMottatt.getSedKontekst().setNavIdent(s));
@@ -106,7 +105,7 @@ public class BehandleSedMottattService {
         sedMottatt.getSedKontekst().setOppgaveID(oppgaveID);
     }
 
-    private void publiserMelding(SedMottatt sedMottatt, SED sed) throws IntegrationException, NotFoundException {
+    private void publiserMelding(SedMottatt sedMottatt, SED sed) throws IntegrationException {
         log.info("Publiserer melding om mottatt sed på kafka for SED {}", sedMottatt.getSedHendelse().getRinaDokumentId());
         MelosysEessiMeldingMapper mapper = MelosysEessiMeldingMapperFactory.getMapper(SedType.valueOf(sed.getSedType()));
         if (mapper == null) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonSok.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonSok.java
@@ -1,5 +1,9 @@
 package no.nav.melosys.eessi.service.identifisering;
 
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
@@ -11,10 +15,6 @@ import no.nav.melosys.eessi.service.tps.personsok.PersonsoekKriterier;
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Person;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
 
 import static no.nav.melosys.eessi.models.DatoUtils.tilLocalDate;
 import static no.nav.melosys.eessi.service.identifisering.PersonKontroller.*;
@@ -30,7 +30,7 @@ class PersonSok {
         this.tpsService = tpsService;
     }
 
-    PersonSokResultat søkPersonFraSed(SED sed) throws IntegrationException, NotFoundException {
+    PersonSokResultat søkPersonFraSed(SED sed) throws IntegrationException {
         List<PersonSoekResponse> personSøk = søkEtterPerson(sed);
         if (personSøk.isEmpty()) {
             return PersonSokResultat.ikkeIdentifisert(SoekBegrunnelse.INGEN_TREFF);
@@ -42,7 +42,7 @@ class PersonSok {
         return vurderPerson(ident, sed);
     }
 
-    PersonSokResultat vurderPerson(String ident, SED sed) throws IntegrationException, NotFoundException {
+    PersonSokResultat vurderPerson(String ident, SED sed) throws IntegrationException {
         Person person;
 
         try {
@@ -60,7 +60,7 @@ class PersonSok {
                 : PersonSokResultat.ikkeIdentifisert(begrunnelse);
     }
 
-    private SoekBegrunnelse vurderPerson(Person person, SED sed) throws NotFoundException {
+    private SoekBegrunnelse vurderPerson(Person person, SED sed) {
         if (erOpphoert(person)) {
             return SoekBegrunnelse.PERSON_OPPHORT;
         } else if (!harSammeStatsborgerskap(person, sed)) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostService.java
@@ -1,12 +1,12 @@
 package no.nav.melosys.eessi.service.joark;
 
 import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.integration.journalpostapi.OpprettJournalpostResponse;
 import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.service.eux.EuxService;
 import no.nav.melosys.eessi.service.oppgave.OppgaveService;
 import no.nav.melosys.eessi.service.sak.SakService;
@@ -35,7 +35,7 @@ public class OpprettUtgaaendeJournalpostService {
         this.oppgaveService = oppgaveService;
     }
 
-    public String arkiverUtgaaendeSed(SedHendelse sedSendt) throws IntegrationException, NotFoundException {
+    public String arkiverUtgaaendeSed(SedHendelse sedSendt) throws IntegrationException {
         Optional<Sak> sak = sakService.finnSakForRinaSaksnummer(sedSendt.getRinaSakId());
 
         if (!sak.isPresent()) {
@@ -45,7 +45,7 @@ public class OpprettUtgaaendeJournalpostService {
         return arkiverMedSak(sedSendt, sak.get());
     }
 
-    private String arkiverMedSak(SedHendelse sedSendt, Sak sak) throws NotFoundException, IntegrationException {
+    private String arkiverMedSak(SedHendelse sedSendt, Sak sak) throws IntegrationException {
         log.info("Journalfører dokument: {}", sedSendt.getRinaDokumentId());
         String navIdent = tpsService.hentNorskIdent(sak.getAktoerId());
         OpprettJournalpostResponse response = opprettUtgåendeJournalpost(sedSendt, sak, navIdent);
@@ -58,7 +58,7 @@ public class OpprettUtgaaendeJournalpostService {
         return response.getJournalpostId();
     }
 
-    private String arkiverUtenSak(SedHendelse sedSendt) throws IntegrationException, NotFoundException {
+    private String arkiverUtenSak(SedHendelse sedSendt) throws IntegrationException {
         log.info("Journalfører dokument uten sakstilknytning: {}", sedSendt.getRinaDokumentId());
 
         String navIdent = sedSendt.getNavBruker();
@@ -73,7 +73,7 @@ public class OpprettUtgaaendeJournalpostService {
                 euxService.hentSedMedVedlegg(sedSendt.getRinaSakId(), sedSendt.getRinaDokumentId()), navIdent);
     }
 
-    private String opprettUtgåendeJournalføringsoppgave(SedHendelse sedSendt, String journalpostId, String navIdent) throws NotFoundException, IntegrationException {
+    private String opprettUtgåendeJournalføringsoppgave(SedHendelse sedSendt, String journalpostId, String navIdent) throws IntegrationException {
         return oppgaveService.opprettUtgåendeJfrOppgave(journalpostId, sedSendt, tpsService.hentAktoerId(navIdent),
                 euxService.hentRinaUrl(sedSendt.getRinaSakId()));
     }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
@@ -15,7 +15,6 @@ import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.buc.Document;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.exception.ValidationException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.service.eux.EuxService;
@@ -42,7 +41,7 @@ public class SedService {
     }
 
     public OpprettSedDto opprettBucOgSed(SedDataDto sedDataDto, SedVedlegg vedlegg, BucType bucType, boolean sendAutomatisk)
-            throws MappingException, IntegrationException, NotFoundException, ValidationException {
+            throws IntegrationException, ValidationException {
 
         Long gsakSaksnummer = hentGsakSaksnummer(sedDataDto);
         log.info("Oppretter buc og sed, gsakSaksnummer: {}", gsakSaksnummer);
@@ -91,14 +90,14 @@ public class SedService {
         }
     }
 
-    public byte[] genererPdfFraSed(SedDataDto sedDataDto, SedType sedType) throws MappingException, NotFoundException, IntegrationException {
+    public byte[] genererPdfFraSed(SedDataDto sedDataDto, SedType sedType) throws IntegrationException {
         SedMapper sedMapper = SedMapperFactory.sedMapper(sedType);
         SED sed = sedMapper.mapTilSed(sedDataDto);
 
         return euxService.genererPdfFraSed(sed);
     }
 
-    public void sendPåEksisterendeBuc(SedDataDto sedDataDto, String rinaSaksnummer, SedType sedType) throws MappingException, NotFoundException, IntegrationException {
+    public void sendPåEksisterendeBuc(SedDataDto sedDataDto, String rinaSaksnummer, SedType sedType) throws IntegrationException {
         BUC buc = euxService.hentBuc(rinaSaksnummer);
         if (!buc.kanOppretteSed(sedType)) {
             throw new IllegalArgumentException("Kan ikke opprette sed med type " + sedType + " på buc "+ rinaSaksnummer + " med type " + buc.getBucType());
@@ -151,7 +150,7 @@ public class SedService {
         return opprettBucOgSedResponse;
     }
 
-    private static Long hentGsakSaksnummer(SedDataDto sedDataDto) throws MappingException {
+    private static Long hentGsakSaksnummer(SedDataDto sedDataDto) {
         return Optional.ofNullable(sedDataDto.getGsakSaksnummer()).orElseThrow(() -> new MappingException("GsakId er påkrevd!"));
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/A1GrunnlagMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/A1GrunnlagMapper.java
@@ -12,7 +12,7 @@ class A1GrunnlagMapper {
     private static final String BESTEMMELSE_16_R  = "16_R";
     private static final String BESTEMMELSE_OTHER = "annet";
 
-    public static String mapFromBestemmelse(Bestemmelse bestemmelse) throws MappingException {
+    public static String mapFromBestemmelse(Bestemmelse bestemmelse) {
         switch (bestemmelse) {
             case ART_12_1:
             case ART_12_2:

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -17,12 +17,12 @@ public final class LandkodeMapper {
 
     static {
         Arrays.stream(Locale.getISOCountries()).forEach(c -> map.put(new Locale("", c).getISO3Country(), c));
-        //TODO: midlertidig fix for landkoder utenfor iso-standard til vi blir enige om hvilke som skal brukes
+        //FIXME: midlertidig fix for landkoder utenfor iso-standard til vi blir enige om hvilke som skal brukes
         map.put("XXX", "XXX"); //Statsløs
         map.put("???", "???"); //Ukjent
     }
 
-    public static String getLandkodeIso2(String landkodeIso3) throws NotFoundException {
+    public static String getLandkodeIso2(String landkodeIso3) {
         if (landkodeIso3 == null) {
             return null;
         }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/PostnummerMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/PostnummerMapper.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
@@ -43,7 +44,7 @@ public final class PostnummerMapper {
                 ));
     }
 
-    public static String getPoststed(String postnummer) throws NotFoundException {
+    public static String getPoststed(String postnummer) {
 
         String poststed = postnummerOgPoststed.get(postnummer);
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/SedMapperFactory.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/SedMapperFactory.java
@@ -43,7 +43,7 @@ public class SedMapperFactory {
 
                     .build());
 
-    public static SedMapper sedMapper(SedType sedType) throws MappingException {
+    public static SedMapper sedMapper(SedType sedType) {
         if (!SED_MAPPERS.containsKey(sedType)) {
             throw new MappingException("Sed-type " + sedType.name() + " støttes ikke");
         }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/SedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/SedMapper.java
@@ -45,7 +45,7 @@ public interface SedMapper {
 
     SedType getSedType();
 
-    default Nav prefillNav(SedDataDto sedData) throws MappingException, NotFoundException {
+    default Nav prefillNav(SedDataDto sedData) {
         Nav nav = new Nav();
 
         nav.setBruker(hentBruker(sedData));
@@ -60,7 +60,7 @@ public interface SedMapper {
         return nav;
     }
 
-    default Bruker hentBruker(SedDataDto sedDataDto) throws NotFoundException {
+    default Bruker hentBruker(SedDataDto sedDataDto) {
         Bruker bruker = new Bruker();
 
         bruker.setPerson(hentPerson(sedDataDto));
@@ -70,7 +70,7 @@ public interface SedMapper {
         return bruker;
     }
 
-    default Person hentPerson(SedDataDto sedData) throws NotFoundException {
+    default Person hentPerson(SedDataDto sedData) {
         Person person = new Person();
 
         person.setFornavn(sedData.getBruker().getFornavn());
@@ -89,7 +89,7 @@ public interface SedMapper {
         return person;
     }
 
-    default List<Pin> hentPin(SedDataDto sedData) throws NotFoundException {
+    default List<Pin> hentPin(SedDataDto sedData) {
         List<Pin> pins = Lists.newArrayList();
 
         pins.add(new Pin(
@@ -106,7 +106,7 @@ public interface SedMapper {
         return pins;
     }
 
-    default List<Adresse> hentAdresser(SedDataDto sedDataDto) throws NotFoundException {
+    default List<Adresse> hentAdresser(SedDataDto sedDataDto) {
 
         Adresse adresse = new Adresse();
         adresse.setBy(sedDataDto.getBostedsadresse().getPoststed());
@@ -158,7 +158,7 @@ public interface SedMapper {
         }
     }
 
-    default List<Arbeidssted> hentArbeidssted(SedDataDto sedData) throws MappingException, NotFoundException {
+    default List<Arbeidssted> hentArbeidssted(SedDataDto sedData) {
 
         List<Arbeidssted> arbeidsstedList = Lists.newArrayList();
 
@@ -283,7 +283,7 @@ public interface SedMapper {
         return periode;
     }
 
-    default String landkodeIso2EllerNull(String iso3) throws NotFoundException {
+    default String landkodeIso2EllerNull(String iso3) {
         if (iso3 == null) {
             return null;
         } else if (iso3.length() == 2) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001Mapper.java
@@ -56,8 +56,9 @@ public class A001Mapper implements LovvalgSedMapper<MedlemskapA001> {
     }
 
     private Vertsland getVertsland(SedDataDto sedData) throws MappingException, NotFoundException {
+        final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Vertsland vertsland = new Vertsland();
-        vertsland.setArbeidsgiver(hentArbeidsGiver(sedData.getUtenlandskeVirksomheter()));
+        vertsland.setArbeidsgiver(hentArbeidsgivereIkkeILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
 
         return vertsland;
     }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001Mapper.java
@@ -8,8 +8,6 @@ import java.util.stream.Collectors;
 import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.SedType;
-import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA001;
 import no.nav.melosys.eessi.models.sed.nav.*;
 import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
@@ -18,7 +16,7 @@ import no.nav.melosys.eessi.service.sed.helpers.UnntakArtikkelMapper;
 public class A001Mapper implements LovvalgSedMapper<MedlemskapA001> {
 
     @Override
-    public MedlemskapA001 getMedlemskap(SedDataDto sedData) throws MappingException, NotFoundException {
+    public MedlemskapA001 getMedlemskap(SedDataDto sedData) {
 
         final MedlemskapA001 medlemskap = new MedlemskapA001();
         final Lovvalgsperiode lovvalgsperiode = getLovvalgsperiode(sedData);
@@ -55,7 +53,7 @@ public class A001Mapper implements LovvalgSedMapper<MedlemskapA001> {
         return unntak;
     }
 
-    private Vertsland getVertsland(SedDataDto sedData) throws MappingException, NotFoundException {
+    private Vertsland getVertsland(SedDataDto sedData) {
         final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Vertsland vertsland = new Vertsland();
         vertsland.setArbeidsgiver(hentArbeidsgivereIkkeILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
@@ -63,7 +61,7 @@ public class A001Mapper implements LovvalgSedMapper<MedlemskapA001> {
         return vertsland;
     }
 
-    private List<Land> getLovvalgsland(Lovvalgsperiode lovvalgsperiode) throws NotFoundException {
+    private List<Land> getLovvalgsland(Lovvalgsperiode lovvalgsperiode) {
         Land land = new Land();
         land.setLandkode(LandkodeMapper.getLandkodeIso2(lovvalgsperiode.getLovvalgsland()));
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A002Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A002Mapper.java
@@ -16,7 +16,7 @@ import no.nav.melosys.eessi.models.sed.nav.Periode;
 public class A002Mapper implements LovvalgSedMapper<MedlemskapA002> {
 
     @Override
-    public MedlemskapA002 getMedlemskap(SedDataDto sedData) throws MappingException {
+    public MedlemskapA002 getMedlemskap(SedDataDto sedData) {
         SvarAnmodningUnntakDto svarAnmodningUnntak = sedData.getSvarAnmodningUnntak();
 
         if (svarAnmodningUnntak == null) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003Mapper.java
@@ -12,7 +12,7 @@ import no.nav.melosys.eessi.models.sed.nav.VedtakA003;
 public class A003Mapper implements LovvalgSedMapper<MedlemskapA003> {
 
     @Override
-    public MedlemskapA003 getMedlemskap(SedDataDto sedData) throws MappingException {
+    public MedlemskapA003 getMedlemskap(SedDataDto sedData) {
 
         MedlemskapA003 medlemskap = new MedlemskapA003();
 
@@ -25,7 +25,7 @@ public class A003Mapper implements LovvalgSedMapper<MedlemskapA003> {
         return medlemskap;
     }
 
-    private VedtakA003 getVedtak(SedDataDto sedData) throws MappingException {
+    private VedtakA003 getVedtak(SedDataDto sedData) {
 
         Lovvalgsperiode lovvalgsperiode = sedData.getLovvalgsperioder().stream().findFirst()
                 .orElseThrow(() -> new MappingException("Finner ingen lovvalgsperiode"));

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003Mapper.java
@@ -5,11 +5,11 @@ import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.exception.MappingException;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA003;
+import no.nav.melosys.eessi.models.sed.nav.Andreland;
 import no.nav.melosys.eessi.models.sed.nav.PeriodeA010;
 import no.nav.melosys.eessi.models.sed.nav.VedtakA003;
 
 public class A003Mapper implements LovvalgSedMapper<MedlemskapA003> {
-
 
     @Override
     public MedlemskapA003 getMedlemskap(SedDataDto sedData) throws MappingException {
@@ -19,6 +19,7 @@ public class A003Mapper implements LovvalgSedMapper<MedlemskapA003> {
         if (!sedData.getLovvalgsperioder().isEmpty()) {
             medlemskap.setVedtak(getVedtak(sedData));
             medlemskap.setRelevantartikkelfor8832004eller9872009(sedData.getLovvalgsperioder().get(0).getBestemmelse().getValue());
+            medlemskap.setAndreland(getAndreLand(sedData));
         }
 
         return medlemskap;
@@ -43,6 +44,14 @@ public class A003Mapper implements LovvalgSedMapper<MedlemskapA003> {
         periode.setStartdato(formaterDato(lovvalgsperiode.getFom()));
         periode.setSluttdato(formaterDato(lovvalgsperiode.getTom()));
         return periode;
+    }
+
+
+    private Andreland getAndreLand(SedDataDto sedData) {
+        final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
+        Andreland andreland = new Andreland();
+        andreland.setArbeidsgiver(hentArbeidsgivereIkkeILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
+        return andreland;
     }
 
     @Override

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A004Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A004Mapper.java
@@ -11,7 +11,7 @@ import no.nav.melosys.eessi.models.sed.nav.Land;
 public class A004Mapper implements LovvalgSedMapper<MedlemskapA004> {
 
     @Override
-    public MedlemskapA004 getMedlemskap(SedDataDto sedData) throws MappingException {
+    public MedlemskapA004 getMedlemskap(SedDataDto sedData) {
         UtpekingAvvisDto utpekingAvvis = sedData.getUtpekingAvvis();
 
         if (utpekingAvvis == null) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A008Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A008Mapper.java
@@ -3,8 +3,6 @@ package no.nav.melosys.eessi.service.sed.mapper.til_sed.lovvalg;
 import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.SedType;
-import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA008;
 import no.nav.melosys.eessi.models.sed.nav.*;
 import org.springframework.util.StringUtils;
@@ -12,7 +10,7 @@ import org.springframework.util.StringUtils;
 public class A008Mapper implements LovvalgSedMapper<MedlemskapA008> {
 
     @Override
-    public MedlemskapA008 getMedlemskap(SedDataDto sedData) throws MappingException, NotFoundException {
+    public MedlemskapA008 getMedlemskap(SedDataDto sedData) {
         MedlemskapA008 medlemskap = new MedlemskapA008();
         if (!StringUtils.isEmpty(sedData.getAvklartBostedsland())) {
             //For videresending av søknad - fyller ut arbeidsland, ikke påkrevd
@@ -46,7 +44,7 @@ public class A008Mapper implements LovvalgSedMapper<MedlemskapA008> {
         return bruker;
     }
 
-    private EndringA008 hentEndringA008(SedDataDto sedData) throws MappingException, NotFoundException {
+    private EndringA008 hentEndringA008(SedDataDto sedData) {
         EndringA008 endring = new EndringA008();
         endring.setAdresse(hentAdresseFraDtoAdresse(sedData.getBostedsadresse()));
         return endring;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009Mapper.java
@@ -40,7 +40,7 @@ public class A009Mapper implements LovvalgSedMapper<MedlemskapA009> {
         vedtak.setGjeldervarighetyrkesaktivitet(
                 "nei"); //Vil være 'ja' om det er åpen periode. Melosys støtter ikke åpen periode.
 
-        if (!isKorrektLovvalgbestemmelse(lovvalgsperiode.getBestemmelse())) {
+        if (!erGyldigLovvalgbestemmelse(lovvalgsperiode.getBestemmelse())) {
             throw new MappingException("Lovvalgsbestemmelse is not of article 12!");
         }
 
@@ -59,24 +59,22 @@ public class A009Mapper implements LovvalgSedMapper<MedlemskapA009> {
         return vedtak;
     }
 
-    private boolean isKorrektLovvalgbestemmelse(Bestemmelse bestemmelse) {
+    private boolean erGyldigLovvalgbestemmelse(Bestemmelse bestemmelse) {
         return bestemmelse == Bestemmelse.ART_12_1
                 || bestemmelse == Bestemmelse.ART_12_2;
     }
 
     private Utsendingsland getUtsendingsland(SedDataDto sedData) throws MappingException, NotFoundException {
+        final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Utsendingsland utsendingsland = new Utsendingsland();
-        utsendingsland.setArbeidsgiver(hentArbeidsGiver(sedData.getArbeidsgivendeVirksomheter()));
+        utsendingsland.setArbeidsgiver(hentArbeidsgivereILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
         return utsendingsland;
     }
 
     private Utsendingsland getAndreland(SedDataDto sedData) throws MappingException, NotFoundException {
-        if (sedData.getUtenlandskeVirksomheter() == null) {
-            return null; //Ikke påkrevd
-        }
-
+        final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Utsendingsland utsendingsland = new Utsendingsland();
-        utsendingsland.setArbeidsgiver(hentArbeidsGiver(sedData.getUtenlandskeVirksomheter()));
+        utsendingsland.setArbeidsgiver(hentArbeidsgivereIkkeILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
         return utsendingsland;
     }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009Mapper.java
@@ -5,7 +5,6 @@ import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA009;
 import no.nav.melosys.eessi.models.sed.nav.Fastperiode;
 import no.nav.melosys.eessi.models.sed.nav.Periode;
@@ -16,7 +15,7 @@ import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
 public class A009Mapper implements LovvalgSedMapper<MedlemskapA009> {
 
     @Override
-    public MedlemskapA009 getMedlemskap(SedDataDto sedData) throws MappingException, NotFoundException {
+    public MedlemskapA009 getMedlemskap(SedDataDto sedData) {
 
         final MedlemskapA009 medlemskapA009 = new MedlemskapA009();
         final Lovvalgsperiode lovvalgsperiode = getLovvalgsperiode(sedData);
@@ -31,7 +30,7 @@ public class A009Mapper implements LovvalgSedMapper<MedlemskapA009> {
         return medlemskapA009;
     }
 
-    private VedtakA009 getVedtak(Lovvalgsperiode lovvalgsperiode) throws MappingException, NotFoundException {
+    private VedtakA009 getVedtak(Lovvalgsperiode lovvalgsperiode) {
         VedtakA009 vedtak = new VedtakA009();
 
         vedtak.setEropprinneligvedtak(
@@ -64,14 +63,14 @@ public class A009Mapper implements LovvalgSedMapper<MedlemskapA009> {
                 || bestemmelse == Bestemmelse.ART_12_2;
     }
 
-    private Utsendingsland getUtsendingsland(SedDataDto sedData) throws MappingException, NotFoundException {
+    private Utsendingsland getUtsendingsland(SedDataDto sedData) {
         final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Utsendingsland utsendingsland = new Utsendingsland();
         utsendingsland.setArbeidsgiver(hentArbeidsgivereILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
         return utsendingsland;
     }
 
-    private Utsendingsland getAndreland(SedDataDto sedData) throws MappingException, NotFoundException {
+    private Utsendingsland getAndreland(SedDataDto sedData) {
         final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Utsendingsland utsendingsland = new Utsendingsland();
         utsendingsland.setArbeidsgiver(hentArbeidsgivereIkkeILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010Mapper.java
@@ -7,7 +7,6 @@ import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA010;
 import no.nav.melosys.eessi.models.sed.nav.MeldingOmLovvalg;
 import no.nav.melosys.eessi.models.sed.nav.PeriodeA010;
@@ -21,7 +20,7 @@ public class A010Mapper implements LovvalgSedMapper<MedlemskapA010> {
     private static final Set<Bestemmelse> LOVLIGE_BESTEMMELSER_A010 = Set.of(ART_11_3_b, ART_11_3_c, ART_11_3_d, ART_11_4, ART_11_5, ART_15);
 
     @Override
-    public MedlemskapA010 getMedlemskap(SedDataDto sedData) throws MappingException, NotFoundException {
+    public MedlemskapA010 getMedlemskap(SedDataDto sedData) {
         MedlemskapA010 medlemskap = new MedlemskapA010();
 
         Lovvalgsperiode lovvalgsperiode = getLovvalgsperiode(sedData);
@@ -35,7 +34,7 @@ public class A010Mapper implements LovvalgSedMapper<MedlemskapA010> {
         return medlemskap;
     }
 
-    private Utsendingsland getAndreland(SedDataDto sedData) throws MappingException, NotFoundException {
+    private Utsendingsland getAndreland(SedDataDto sedData) {
         final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Utsendingsland utsendingsland = new Utsendingsland();
         utsendingsland.setArbeidsgiver(hentArbeidsgivereIkkeILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
@@ -51,13 +50,13 @@ public class A010Mapper implements LovvalgSedMapper<MedlemskapA010> {
         return vedtak;
     }
 
-    private MeldingOmLovvalg hentMeldingOmLovvalg(Lovvalgsperiode lovvalgsperiode) throws MappingException {
+    private MeldingOmLovvalg hentMeldingOmLovvalg(Lovvalgsperiode lovvalgsperiode) {
         MeldingOmLovvalg meldingOmLovvalg = new MeldingOmLovvalg();
         meldingOmLovvalg.setArtikkel(tilA010Bestemmelse(lovvalgsperiode));
         return  meldingOmLovvalg;
     }
 
-    private String tilA010Bestemmelse(Lovvalgsperiode lovvalgsperiode) throws MappingException {
+    private String tilA010Bestemmelse(Lovvalgsperiode lovvalgsperiode) {
 
         if (LOVLIGE_BESTEMMELSER_A010.contains(lovvalgsperiode.getBestemmelse())) {
             return lovvalgsperiode.getBestemmelse().getValue();

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010Mapper.java
@@ -36,12 +36,9 @@ public class A010Mapper implements LovvalgSedMapper<MedlemskapA010> {
     }
 
     private Utsendingsland getAndreland(SedDataDto sedData) throws MappingException, NotFoundException {
-        if (sedData.getUtenlandskeVirksomheter() == null) {
-            return null; //Ikke påkrevd
-        }
-
+        final String lovvalgsland = sedData.finnLovvalgslandDefaultNO();
         Utsendingsland utsendingsland = new Utsendingsland();
-        utsendingsland.setArbeidsgiver(hentArbeidsGiver(sedData.getUtenlandskeVirksomheter()));
+        utsendingsland.setArbeidsgiver(hentArbeidsgivereIkkeILand(sedData.getArbeidsgivendeVirksomheter(), lovvalgsland));
         return utsendingsland;
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001MapperTest.java
@@ -3,7 +3,6 @@ package no.nav.melosys.eessi.service.sed.mapper.til_sed.lovvalg;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
-import java.util.Collections;
 
 import no.nav.melosys.eessi.controller.dto.Bestemmelse;
 import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
@@ -18,8 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class A001MapperTest {
@@ -32,14 +31,13 @@ public class A001MapperTest {
     public void setup() throws IOException, URISyntaxException {
         sedData = SedDataStub.getStub();
 
-        Lovvalgsperiode lovvalgsperiode = new Lovvalgsperiode();
+        Lovvalgsperiode lovvalgsperiode = sedData.getLovvalgsperioder().get(0);
         lovvalgsperiode.setBestemmelse(Bestemmelse.ART_16_1);
         lovvalgsperiode.setFom(LocalDate.now());
         lovvalgsperiode.setTom(LocalDate.now().plusYears(1L));
-        lovvalgsperiode.setLovvalgsland("NOR");
-        lovvalgsperiode.setUnntakFraLovvalgsland("NOR");
+        lovvalgsperiode.setLovvalgsland("NO");
+        lovvalgsperiode.setUnntakFraLovvalgsland("SE");
         lovvalgsperiode.setUnntakFraBestemmelse(Bestemmelse.ART_16_1);
-        sedData.setLovvalgsperioder(Collections.singletonList(lovvalgsperiode));
     }
 
     @Test
@@ -48,12 +46,11 @@ public class A001MapperTest {
 
         assertEquals(MedlemskapA001.class, sed.getMedlemskap().getClass());
 
-        MedlemskapA001 medlemskap = (MedlemskapA001) sed.getMedlemskap();
+        assertThat(sed.getMedlemskap()).isNotNull().isInstanceOf(MedlemskapA001.class);
 
-        assertNotNull(medlemskap);
-        assertNotNull(medlemskap.getAnmodning().getErendring());
-        assertNotNull(medlemskap.getUnntak().getGrunnlag());
-        assertNotNull(medlemskap.getSoeknadsperiode());
+        MedlemskapA001 medlemskapA001 = (MedlemskapA001) sed.getMedlemskap();
+        assertThat(sed.getNav().getArbeidsgiver()).allMatch(a -> "NO".equalsIgnoreCase(a.getAdresse().getLand()));
+        assertThat(medlemskapA001.getVertsland().getArbeidsgiver()).noneMatch(a -> "NO".equalsIgnoreCase(a.getAdresse().getLand()));
     }
 }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003MapperTest.java
@@ -11,7 +11,7 @@ import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA003;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
 import org.junit.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class A003MapperTest {
 
@@ -20,9 +20,14 @@ public class A003MapperTest {
     @Test
     public void mapTilSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
         SedDataDto sedDataDto = SedDataStub.getStub();
+        sedDataDto.getLovvalgsperioder().get(0).setLovvalgsland("NO");
         SED sed = sedMapper.mapTilSed(sedDataDto);
 
         assertThat(sed).isNotNull();
         assertThat(sed.getMedlemskap()).isInstanceOf(MedlemskapA003.class);
+
+        MedlemskapA003 medlemskapA003 = (MedlemskapA003) sed.getMedlemskap();
+        assertThat(sed.getNav().getArbeidsgiver()).allMatch(a -> "NO".equals(a.getAdresse().getLand()));
+        assertThat(medlemskapA003.getAndreland().getArbeidsgiver()).noneMatch(a -> "NO".equals(a.getAdresse().getLand()));
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
@@ -3,7 +3,6 @@ package no.nav.melosys.eessi.service.sed.mapper.til_sed.lovvalg;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
-import java.util.Collections;
 
 import no.nav.melosys.eessi.controller.dto.Bestemmelse;
 import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
@@ -26,16 +25,17 @@ public class A009MapperTest {
 
     private SedDataDto sedData;
 
+    private final String lovvalgsland = "NO";
+
     @Before
     public void setup() throws IOException, URISyntaxException {
         sedData = SedDataStub.getStub();
 
-        Lovvalgsperiode lovvalgsperiode = new Lovvalgsperiode();
+        Lovvalgsperiode lovvalgsperiode = sedData.getLovvalgsperioder().get(0);
         lovvalgsperiode.setBestemmelse(Bestemmelse.ART_12_1);
         lovvalgsperiode.setFom(LocalDate.now());
         lovvalgsperiode.setTom(LocalDate.now().plusYears(1L));
-        lovvalgsperiode.setLovvalgsland("NO");
-        sedData.setLovvalgsperioder(Collections.singletonList(lovvalgsperiode));
+        lovvalgsperiode.setLovvalgsland(lovvalgsland);
     }
 
     @Test
@@ -48,8 +48,8 @@ public class A009MapperTest {
 
         assertThat(medlemskapA009).isNotNull();
         assertThat(medlemskapA009.getUtsendingsland()).isNotNull();
-        assertThat(medlemskapA009.getUtsendingsland().getArbeidsgiver().get(0).getNavn()).isEqualTo(
-                sed.getNav().getArbeidsgiver().get(0).getNavn());
+        assertThat(medlemskapA009.getUtsendingsland().getArbeidsgiver()).allMatch(a -> a.getAdresse().getLand().equals(lovvalgsland));
+        assertThat(medlemskapA009.getAndreland().getArbeidsgiver()).noneMatch(a -> a.getAdresse().getLand().equals(lovvalgsland));
 
         assertThat(medlemskapA009.getVedtak()).isNotNull();
         assertThat(medlemskapA009.getVedtak().getArtikkelforordning()).isEqualTo("12_1");

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
@@ -9,7 +9,6 @@ import no.nav.melosys.eessi.controller.dto.Bestemmelse;
 import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA009;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
@@ -40,7 +39,7 @@ public class A009MapperTest {
     }
 
     @Test
-    public void getMedlemskapIkkeSelvstendigOg12_1_expectGyldigMedlemskap() throws MappingException, NotFoundException {
+    public void getMedlemskapIkkeSelvstendigOg12_1_expectGyldigMedlemskap() {
         SED sed = a009Mapper.mapTilSed(sedData);
 
         assertThat(MedlemskapA009.class).isEqualTo(sed.getMedlemskap().getClass());
@@ -59,7 +58,7 @@ public class A009MapperTest {
     }
 
     @Test
-    public void getMedlemskapErSelvstendigOg12_2_expectGyldigMedlemskap() throws MappingException, NotFoundException {
+    public void getMedlemskapErSelvstendigOg12_2_expectGyldigMedlemskap() {
         sedData.getLovvalgsperioder().get(0).setBestemmelse(Bestemmelse.ART_12_2);
         SED sed = a009Mapper.mapTilSed(sedData);
 
@@ -76,19 +75,19 @@ public class A009MapperTest {
     }
 
     @Test(expected = MappingException.class)
-    public void getMedlemskapFeilLovvalgsBestemmelse_expectMappingException() throws MappingException, NotFoundException {
+    public void getMedlemskapFeilLovvalgsBestemmelse_expectMappingException() {
         sedData.getLovvalgsperioder().get(0).setBestemmelse(Bestemmelse.ART_13_4);
         a009Mapper.mapTilSed(sedData);
     }
 
     @Test(expected = NullPointerException.class)
-    public void ingenLovvalgsperioder_expectNullPointerException() throws MappingException, NotFoundException {
+    public void ingenLovvalgsperioder_expectNullPointerException() {
         sedData.setLovvalgsperioder(null);
         a009Mapper.mapTilSed(sedData);
     }
 
     @Test
-    public void erIkkeFysisk_forventErIkkeFastadresse() throws MappingException, NotFoundException {
+    public void erIkkeFysisk_forventErIkkeFastadresse() {
         sedData.getArbeidssteder().get(0).setFysisk(false);
         SED sed = a009Mapper.mapTilSed(sedData);
         assertThat(sed.getNav().getArbeidssted().get(0).getErikkefastadresse()).isEqualTo("ja");

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
@@ -35,7 +35,7 @@ public class A009MapperTest {
         lovvalgsperiode.setBestemmelse(Bestemmelse.ART_12_1);
         lovvalgsperiode.setFom(LocalDate.now());
         lovvalgsperiode.setTom(LocalDate.now().plusYears(1L));
-        lovvalgsperiode.setLovvalgsland("NOR");
+        lovvalgsperiode.setLovvalgsland("NO");
         sedData.setLovvalgsperioder(Collections.singletonList(lovvalgsperiode));
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
@@ -8,7 +8,6 @@ import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA010;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
@@ -34,7 +33,7 @@ public class A010MapperTest {
     }
 
     @Test
-    public void mapTilSed_medTilleggsbestemmelse_bestemmelseErLovligBlirMappetTilSed() throws MappingException, NotFoundException {
+    public void mapTilSed_medTilleggsbestemmelse_bestemmelseErLovligBlirMappetTilSed() {
         lovvalgsperiode.setBestemmelse(Bestemmelse.ART_11_3_b);
         lovvalgsperiode.setTilleggsBestemmelse(Bestemmelse.ART_11_3_c);
 
@@ -54,7 +53,7 @@ public class A010MapperTest {
     }
 
     @Test
-    public void mapTilSed_medTilleggsbestemmelseBestemmelseIkkeGyld_tilleggsBestemmelseBrukes() throws MappingException, NotFoundException {
+    public void mapTilSed_medTilleggsbestemmelseBestemmelseIkkeGyld_tilleggsBestemmelseBrukes() {
         lovvalgsperiode.setBestemmelse(Bestemmelse.ART_11_3_a);
         lovvalgsperiode.setTilleggsBestemmelse(Bestemmelse.ART_11_3_b);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
@@ -2,8 +2,6 @@ package no.nav.melosys.eessi.service.sed.mapper.til_sed.lovvalg;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.time.LocalDate;
-import java.util.Collections;
 
 import no.nav.melosys.eessi.controller.dto.Bestemmelse;
 import no.nav.melosys.eessi.controller.dto.Lovvalgsperiode;
@@ -17,7 +15,7 @@ import no.nav.melosys.eessi.service.sed.SedDataStub;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 
@@ -31,11 +29,8 @@ public class A010MapperTest {
     @Before
     public void setup() throws IOException, URISyntaxException {
         sedData = SedDataStub.getStub();
-        lovvalgsperiode = new Lovvalgsperiode();
-        lovvalgsperiode.setFom(LocalDate.now());
-        lovvalgsperiode.setTom(LocalDate.now().plusYears(1L));
-        lovvalgsperiode.setLovvalgsland("NOR");
-        sedData.setLovvalgsperioder(Collections.singletonList(lovvalgsperiode));
+        lovvalgsperiode = sedData.getLovvalgsperioder().get(0);
+        lovvalgsperiode.setLovvalgsland("NO");
     }
 
     @Test
@@ -48,12 +43,14 @@ public class A010MapperTest {
         assertThat(sed).isNotNull();
         assertThat(sed.getSedType()).isEqualTo(SedType.A010.name());
         assertThat(sed.getMedlemskap()).isInstanceOf(MedlemskapA010.class);
+        assertThat(sed.getNav().getArbeidsgiver()).allMatch(a -> "NO".equals(a.getAdresse().getLand()));
 
         MedlemskapA010 medlemskap = (MedlemskapA010) sed.getMedlemskap();
 
         assertThat(medlemskap.getMeldingomlovvalg().getArtikkel()).isEqualTo(lovvalgsperiode.getBestemmelse().getValue());
         assertThat(medlemskap.getVedtak().getGjelderperiode().getStartdato()).isNotNull();
         assertThat(medlemskap.getVedtak().getGjelderperiode().getSluttdato()).isNotNull();
+        assertThat(medlemskap.getAndreland().getArbeidsgiver()).noneMatch(a -> "NO".equals(a.getAdresse().getLand()));
     }
 
     @Test

--- a/melosys-eessi-app/src/test/resources/mock/sedDataDtoStub.json
+++ b/melosys-eessi-app/src/test/resources/mock/sedDataDtoStub.json
@@ -10,6 +10,17 @@
       "navn": "Lala AS",
       "orgnr": "12312321",
       "type": "type"
+    },
+    {
+      "adresse": {
+        "gateadresse": "testadresse",
+        "land": "SE",
+        "postnr": "1212",
+        "poststed": "Hønefoss"
+      },
+      "navn": "fe",
+      "orgnr": "12312312",
+      "type": "few"
     }
   ],
   "arbeidssteder": [
@@ -57,8 +68,8 @@
     {
       "bestemmelse": "ART_12_1",
       "fom": "2020-01-01",
-      "lovvalgsland": "SE",
-      "unntakFraLovvalgsland": "NO",
+      "lovvalgsland": "NO",
+      "unntakFraLovvalgsland": "SE",
       "tom": "2020-01-01"
     }
   ],
@@ -81,21 +92,7 @@
       "landkode": "SE"
     }
   ],
-  "utenlandskeVirksomheter": [
-    {
-      "adresse": {
-        "gateadresse": "testadresse",
-        "land": "SE",
-        "postnr": "1212",
-        "poststed": "Hønefoss"
-      },
-      "navn": "fe",
-      "orgnr": "12312312",
-      "type": "few"
-    }
-  ],
   "gsakSaksnummer": 123,
-  "mottakerLand": "SE",
   "mottakerIder": [
     "SE:123",
     "BE:312"


### PR DESCRIPTION
Fikser mapping til arbeidsgiver til SED - slik at disse settes i enkelte felt ut fra hvilket lovvalgsland som er valgt.

Gjør også om en del exceptions til unchecked, for å bedre kunne utnytte streams i samme slengen. Hovedsakelig exceptions som kastes ved validerings-feil i mapping.