### PR TITLE
BUGFIX - NPE ved tom adresse for arbeidsgiver

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/Adresse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/Adresse.java
@@ -15,6 +15,10 @@ public class Adresse {
     private Adressetype adressetype;
 
     public static Adresse av(no.nav.melosys.eessi.models.sed.nav.Adresse adresseFraRina) {
+        if (adresseFraRina == null) {
+            return new Adresse();
+        }
+
         Adresse adresse = new Adresse();
 
         adresse.poststed = adresseFraRina.getBy();

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/sed_grunnlag/SedGrunnlagMapperA003.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/sed_grunnlag/SedGrunnlagMapperA003.java
@@ -72,11 +72,19 @@ public class SedGrunnlagMapperA003 extends FraSedA003Mapper implements NyttLovva
     }
 
     private static boolean erNorskArbeidsgiver(Arbeidsgiver arbeidsgiver) {
-        return "NO".equalsIgnoreCase(arbeidsgiver.getAdresse().getLand());
+        return "NO".equalsIgnoreCase(hentArbeidsgiverLand(arbeidsgiver));
     }
 
     private static boolean erUtenlandskArbeidsgiver(Arbeidsgiver arbeidsgiver) {
         return !erNorskArbeidsgiver(arbeidsgiver);
+    }
+
+    private static String hentArbeidsgiverLand(Arbeidsgiver arbeidsgiver) {
+        if (arbeidsgiver == null || arbeidsgiver.getAdresse() == null) {
+            return null;
+        }
+
+        return arbeidsgiver.getAdresse().getLand();
     }
 
     @Override

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/sed_grunnlag/SedGrunnlagMapperA003Test.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/sed_grunnlag/SedGrunnlagMapperA003Test.java
@@ -3,10 +3,13 @@ package no.nav.melosys.eessi.service.sed.mapper.fra_sed.sed_grunnlag;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import no.nav.melosys.eessi.controller.dto.*;
 import no.nav.melosys.eessi.models.sed.SED;
+import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA003;
+import no.nav.melosys.eessi.models.sed.nav.Arbeidsgiver;
 import no.nav.melosys.eessi.models.sed.nav.Pin;
 import org.junit.Test;
 
@@ -127,6 +130,17 @@ public class SedGrunnlagMapperA003Test {
         sed.getNav().getBruker().setAdresse(List.of(adresse));
 
         assertThat(new SedGrunnlagMapperA003().map(sed).getBostedsadresse().getGateadresse()).isEqualTo("Testgate");
+    }
+
+    @Test
+    public void map_ingenArbeidsgiverAdresse_forventIkkeNorskArbeidsgiver() throws IOException {
+        Consumer<Arbeidsgiver> settTomAdresse = (Arbeidsgiver arbeidsgiver) -> arbeidsgiver.setAdresse(null);
+
+        SED sed = hentSed();
+        sed.getNav().getArbeidsgiver().forEach(settTomAdresse);
+        ((MedlemskapA003) sed.getMedlemskap()).getAndreland().getArbeidsgiver().forEach(settTomAdresse);
+
+        assertThat(new SedGrunnlagMapperA003().map(sed).getNorskeArbeidsgivendeVirksomheter()).isEmpty();
     }
 
     private static SED hentSed() throws IOException {


### PR DESCRIPTION
Vi har noen behandlinger i q2 som har feilet fordi vi fikk NPE når arbeidsgivers adresse ikke er satt. Legger til nullsjekk ved henting og mapping av arbeidsgivers adresse.