### PR TITLE
Melosys 3700  sed v42

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
@@ -27,6 +27,8 @@ public class BUC {
     private List<Action> actions;
     @JsonProperty(value = "processDefinitionName")
     private String bucType;
+    @JsonProperty(value = "processDefinitionVersion")
+    private String bucVersjon;
 
     public boolean kanOppretteSed(SedType sedType) {
         return actions.stream().anyMatch(action ->

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BucUtils.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BucUtils.java
@@ -2,13 +2,22 @@ package no.nav.melosys.eessi.models.buc;
 
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.controller.dto.SedStatus;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
+import no.nav.melosys.eessi.models.sed.SED;
 
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_G_VER;
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_VER;
+
+@Slf4j
 @UtilityClass
 public class BucUtils {
 
@@ -31,4 +40,27 @@ public class BucUtils {
             !document.getConversations().isEmpty()
             && document.getConversations().get(0).getVersionId() != null
             && lovvalgSedTyper.contains(document.getType());
+
+    private static final Pattern VERSJON_PATTERN = Pattern.compile("^v(\\d)\\.(\\d)$");
+
+    public static void verifiserSedVersjonErBucVersjon(BUC buc, SED sed) {
+        final String ønsketSedVersjon = String.format("v%s.%s", sed.getSedGVer(), sed.getSedVer());
+
+        if (!ønsketSedVersjon.equalsIgnoreCase(buc.getBucVersjon())) {
+            log.info("Rina-sak {} er på gammel versjon {}. Oppdaterer SED til å bruke gammel versjon", buc.getId(), buc.getBucVersjon());
+            sed.setSedGVer(BucUtils.parseGVer(buc));
+            sed.setSedVer(BucUtils.parseVer(buc));
+        }
+    }
+
+    String parseGVer(BUC buc) {
+        Matcher matcher = VERSJON_PATTERN.matcher(buc.getBucVersjon());
+        return matcher.find() ? matcher.group(1) : DEFAULT_SED_G_VER;
+    }
+
+    String parseVer(BUC buc) {
+        Matcher matcher = VERSJON_PATTERN.matcher(buc.getBucVersjon());
+        return matcher.find() ? matcher.group(2) : DEFAULT_SED_VER;
+    }
+
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/Konstanter.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/Konstanter.java
@@ -9,7 +9,7 @@ public class Konstanter {
 
     public static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    //Versjonen til SED'en. Generasjon og versjon (SED_G_VER.SED_VER = 4.1)
+    //Versjonen til SED'en. Generasjon og versjon (SED_G_VER.SED_VER = 4.2)
     public static final String DEFAULT_SED_G_VER = "4";
-    public static final String DEFAULT_SED_VER = "1";
+    public static final String DEFAULT_SED_VER = "2";
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/Konstanter.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/Konstanter.java
@@ -2,13 +2,14 @@ package no.nav.melosys.eessi.models.sed;
 
 import java.time.format.DateTimeFormatter;
 
-public final class Constants {
+import lombok.experimental.UtilityClass;
 
-    private Constants() {}
+@UtilityClass
+public class Konstanter {
 
     public static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     //Versjonen til SED'en. Generasjon og versjon (SED_G_VER.SED_VER = 4.1)
-    public static final String SED_G_VER = "4";
-    public static final String SED_VER = "1";
+    public static final String DEFAULT_SED_G_VER = "4";
+    public static final String DEFAULT_SED_VER = "1";
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.java
@@ -26,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import static no.nav.melosys.eessi.models.buc.BucUtils.verifiserSedVersjonErBucVersjon;
+
 @Slf4j
 @Service
 public class SedService {
@@ -104,6 +106,7 @@ public class SedService {
         }
 
         SED sed = SedMapperFactory.sedMapper(sedType).mapTilSed(sedDataDto);
+        verifiserSedVersjonErBucVersjon(buc, sed);
         euxService.opprettOgSendSed(sed, rinaSaksnummer);
     }
 
@@ -121,6 +124,7 @@ public class SedService {
                 if (document.isPresent() && buc.sedKanOppdateres(document.get().getId())) {
                     String rinaSaksnummer = buc.getId();
                     String dokumentId = document.get().getId();
+                    verifiserSedVersjonErBucVersjon(buc, sed);
                     log.info("SED {} på rinasak {} oppdateres", dokumentId, rinaSaksnummer);
                     euxService.oppdaterSed(rinaSaksnummer, dokumentId, sed);
                     return new OpprettBucOgSedResponse(rinaSaksnummer, dokumentId);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/SedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/SedMapper.java
@@ -13,7 +13,7 @@ import com.google.common.collect.Lists;
 import no.nav.melosys.eessi.controller.dto.*;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.sed.Constants;
+import no.nav.melosys.eessi.models.sed.Konstanter;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.nav.Adresse;
 import no.nav.melosys.eessi.models.sed.nav.Arbeidssted;
@@ -24,8 +24,8 @@ import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
 import no.nav.melosys.eessi.service.sed.helpers.PostnummerMapper;
 import org.springframework.util.StringUtils;
 
-import static no.nav.melosys.eessi.models.sed.Constants.SED_G_VER;
-import static no.nav.melosys.eessi.models.sed.Constants.SED_VER;
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_G_VER;
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_VER;
 
 /**
  * Felles mapper-interface for alle typer SED. Mapper NAV-objektet i NAV-SED, som brukes av eux for
@@ -37,8 +37,8 @@ public interface SedMapper {
 
         sed.setNav(prefillNav(sedData));
         sed.setSedType(getSedType().name());
-        sed.setSedGVer(SED_G_VER);
-        sed.setSedVer(SED_VER);
+        sed.setSedGVer(DEFAULT_SED_G_VER);
+        sed.setSedVer(DEFAULT_SED_VER);
 
         return sed;
     }
@@ -224,7 +224,7 @@ public interface SedMapper {
     }
 
     default String formaterDato(LocalDate dato) {
-        return Constants.dateTimeFormatter.format(dato);
+        return Konstanter.dateTimeFormatter.format(dato);
     }
 
     default Adresse hentAdresseFraDtoAdresse(no.nav.melosys.eessi.controller.dto.Adresse sAdresse) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/administrativ/X001Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/administrativ/X001Mapper.java
@@ -3,12 +3,12 @@ package no.nav.melosys.eessi.service.sed.mapper.til_sed.administrativ;
 import java.time.LocalDate;
 
 import no.nav.melosys.eessi.models.SedType;
-import no.nav.melosys.eessi.models.sed.Constants;
+import no.nav.melosys.eessi.models.sed.Konstanter;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.nav.*;
 
-import static no.nav.melosys.eessi.models.sed.Constants.SED_G_VER;
-import static no.nav.melosys.eessi.models.sed.Constants.SED_VER;
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_G_VER;
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_VER;
 
 
 public class X001Mapper implements AdministrativSedMapper {
@@ -16,8 +16,8 @@ public class X001Mapper implements AdministrativSedMapper {
     public SED mapFraSed(SED sed, String aarsak) {
         SED x001 = new SED();
         x001.setSedType(SedType.X001.toString());
-        x001.setSedGVer(SED_G_VER);
-        x001.setSedVer(SED_VER);
+        x001.setSedGVer(DEFAULT_SED_G_VER);
+        x001.setSedVer(DEFAULT_SED_VER);
         x001.setNav(mapNav(sed, aarsak));
 
         return x001;
@@ -49,7 +49,7 @@ public class X001Mapper implements AdministrativSedMapper {
         aarsak.setType(aarsakType);
 
         Avslutning avslutning = new Avslutning();
-        avslutning.setDato(LocalDate.now().format(Constants.dateTimeFormatter));
+        avslutning.setDato(LocalDate.now().format(Konstanter.dateTimeFormatter));
         avslutning.setAarsak(aarsak);
         avslutning.setType("automatisk");
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A011Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A011Mapper.java
@@ -5,16 +5,16 @@ import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA011;
 
-import static no.nav.melosys.eessi.models.sed.Constants.SED_G_VER;
-import static no.nav.melosys.eessi.models.sed.Constants.SED_VER;
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_G_VER;
+import static no.nav.melosys.eessi.models.sed.Konstanter.DEFAULT_SED_VER;
 
 public class A011Mapper implements LovvalgSedMapper<MedlemskapA011> {
 
     public SED mapFraSed(SED sed) {
         SED a011 = new SED();
         a011.setSedType(SedType.A011.toString());
-        a011.setSedGVer(SED_G_VER);
-        a011.setSedVer(SED_VER);
+        a011.setSedGVer(DEFAULT_SED_G_VER);
+        a011.setSedVer(DEFAULT_SED_VER);
         a011.setNav(sed.getNav());
         a011.setMedlemskap(new MedlemskapA011());
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
@@ -69,6 +69,7 @@ public class EuxConsumerTest {
         assertThat(response.getDocuments()).isNotEmpty();
         assertThat(response.getDocuments().get(0).getId()).isEqualTo("93f022ea50e54c08bbdb85290a5fb23d");
         assertThat(response.getBucType()).isEqualTo("LA_BUC_01");
+        assertThat(response.getBucVersjon()).isEqualTo("v4.1");
 
         assertThat(response.getDocuments())
                 .flatExtracting(Document::getConversations)

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/buc/BucUtilsTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/buc/BucUtilsTest.java
@@ -1,0 +1,55 @@
+package no.nav.melosys.eessi.models.buc;
+
+
+import no.nav.melosys.eessi.models.sed.Konstanter;
+import no.nav.melosys.eessi.models.sed.SED;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BucUtilsTest {
+
+    private BUC buc = new BUC();
+    private SED sed = new SED();
+
+    @Test
+    public void verifiserSedVersjonErBucVersjon_erLikVersjon_oppdateresIkke() {
+
+        buc.setBucVersjon("v4.1");
+        sed.setSedGVer("4");
+        sed.setSedVer("1");
+
+        BucUtils.verifiserSedVersjonErBucVersjon(buc, sed);
+        assertThat(sed.getSedGVer()).isEqualTo("4");
+        assertThat(sed.getSedVer()).isEqualTo("1");
+    }
+
+    @Test
+    public void verifiserSedVersjonErBucVersjon_erForskjelligVersjon_oppdateres() {
+
+        buc.setBucVersjon("v5.4");
+        sed.setSedGVer("4");
+        sed.setSedVer("1");
+
+        BucUtils.verifiserSedVersjonErBucVersjon(buc, sed);
+        assertThat(sed.getSedGVer()).isEqualTo("5");
+        assertThat(sed.getSedVer()).isEqualTo("4");
+    }
+
+    @Test
+    public void hentBucVersjon_riktigFormat_fungerer() {
+        buc.setBucVersjon("v4.0");
+
+        assertThat(BucUtils.parseGVer(buc)).isEqualTo("4");
+        assertThat(BucUtils.parseVer(buc)).isEqualTo("0");
+    }
+
+    @Test
+    public void hentBucVersjon_uventetFormat_fårDefault() {
+        buc.setBucVersjon("v21");
+
+        assertThat(BucUtils.parseGVer(buc)).isEqualTo(Konstanter.DEFAULT_SED_G_VER);
+        assertThat(BucUtils.parseVer(buc)).isEqualTo(Konstanter.DEFAULT_SED_VER);
+    }
+
+}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.java
@@ -105,7 +105,7 @@ public class SedServiceTest {
     }
 
     @Test
-    public void createAndSend_sedEksistererPaaBuc_forventOppdaterEksisterendeSed() throws Exception {
+    public void opprettBucOgSed_sedEksistererPaaBuc_forventOppdaterEksisterendeSed() throws Exception {
         Long gsakSaksnummer = 123L;
         SedDataDto sedDataDto = SedDataStub.getStub();
         sedDataDto.setGsakSaksnummer(gsakSaksnummer);
@@ -119,6 +119,7 @@ public class SedServiceTest {
 
         BUC buc = new BUC();
         buc.setId(RINA_ID);
+        buc.setBucVersjon("v4.1");
         buc.setStatus("open");
 
         String emptyDocumentId = "docid12314";
@@ -177,6 +178,7 @@ public class SedServiceTest {
     @Test
     public void sendPåEksisterendeBuc_forventMetodekall() throws IOException, URISyntaxException, IntegrationException, NotFoundException, MappingException {
         BUC buc = new BUC();
+        buc.setBucVersjon("v4.1");
         buc.setActions(Arrays.asList(
                 new Action("A001", "A001", "111", "Read"),
                 new Action("A009", "A009", "222", "Create")
@@ -193,6 +195,7 @@ public class SedServiceTest {
     @Test(expected = IllegalArgumentException.class)
     public void sendPåEksisterendeBuc_kanIkkeOpprettesPåBuc_forventException() throws IntegrationException, NotFoundException, MappingException, IOException, URISyntaxException {
         BUC buc = new BUC();
+        buc.setBucVersjon("v4.1");
         buc.setActions(Collections.singletonList(new Action("A001", "A001", "111", "Read")));
         when(euxService.hentBuc(anyString())).thenReturn(buc);
 


### PR DESCRIPTION
Fra story; 
>Etter 13. juni må alle SEDer i nye BUCer opprettes med v4.2. Gamle BUCer hvor det allerede er utvekslet 4.1 må fortsette utveksling i v4.1

Jeg oppdaterer også default SED-versjon til å være 4.2