### PR TITLE
Sett maks fil+request-størrelse til dobbelt av default

### DIFF
--- a/melosys-eessi-app/src/main/resources/application.yml
+++ b/melosys-eessi-app/src/main/resources/application.yml
@@ -28,6 +28,11 @@ spring:
       sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="${melosys.systemuser.username}" password="${melosys.systemuser.password}";
       reconnect.backoff.ms: 1000
 
+  servlet:
+    multipart:
+      max-file-size: 2097152 # 2MB
+      max-request-size: 2097152 # 2MB
+
 melosys:
   kafka:
     consumer:

--- a/melosys-eessi-app/src/main/resources/application.yml
+++ b/melosys-eessi-app/src/main/resources/application.yml
@@ -30,8 +30,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 2097152 # 2MB
-      max-request-size: 2097152 # 2MB
+      max-file-size: 10485760 # 10MB
+      max-request-size: 10485760 # 10MB
 
 melosys:
   kafka:


### PR DESCRIPTION
Det står ikke i loggen hvor stor fila som feila var, men håper det holder å doble. Hvis ikke får jeg prøve å se om jeg kan få logga det på en eller annen måte. 

Har testa lokalt med Postman.