### PR TITLE
Støtt henting av mottakerinstitusjoner for flere land per buc

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
@@ -1,5 +1,6 @@
 package no.nav.melosys.eessi.controller;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -58,9 +59,9 @@ public class BucController {
     }
 
     @ApiOperation(value = "Henter mottakerinstitusjoner som er satt som EESSI-klare for den spesifikke buc-type")
-    @GetMapping("/{bucType}/institusjoner")
+    @PostMapping("/{bucType}/institusjoner")
     public List<InstitusjonDto> hentMottakerinstitusjoner(@PathVariable BucType bucType,
-                                                          @RequestParam(required = false) String land)  {
+                                                          @RequestBody(required = false) Collection<String> land)  {
         return euxService.hentMottakerinstitusjoner(bucType.name(), land).stream()
                 .map(institusjon -> new InstitusjonDto(institusjon.getId(), institusjon.getNavn(), institusjon.getLandkode()))
                 .collect(Collectors.toList());

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/BucController.java
@@ -59,9 +59,9 @@ public class BucController {
     }
 
     @ApiOperation(value = "Henter mottakerinstitusjoner som er satt som EESSI-klare for den spesifikke buc-type")
-    @PostMapping("/{bucType}/institusjoner")
+    @GetMapping("/{bucType}/institusjoner")
     public List<InstitusjonDto> hentMottakerinstitusjoner(@PathVariable BucType bucType,
-                                                          @RequestBody(required = false) Collection<String> land)  {
+                                                          @RequestParam(required = false) Collection<String> land)  {
         return euxService.hentMottakerinstitusjoner(bucType.name(), land).stream()
                 .map(institusjon -> new InstitusjonDto(institusjon.getId(), institusjon.getNavn(), institusjon.getLandkode()))
                 .collect(Collectors.toList());

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -76,11 +76,11 @@ public class EuxService {
         euxConsumer.oppdaterSed(rinaSaksnummer, dokumentId, sed);
     }
 
-    public List<Institusjon> hentMottakerinstitusjoner(final String bucType, final String landkode) {
+    public List<Institusjon> hentMottakerinstitusjoner(final String bucType, final Collection<String> landkoder) {
 
         return euxConsumer.hentInstitusjoner(bucType, null).stream()
                 .peek(i -> i.setLandkode(LandkodeMapper.mapTilNavLandkode(i.getLandkode())))
-                .filter(i -> filtrerPåLandkode(i, landkode))
+                .filter(i -> filtrerPåLandkoder(i, landkoder))
                 .filter(i -> i.getTilegnetBucs().stream().filter(
                         tilegnetBuc -> bucType.equals(tilegnetBuc.getBucType()) &&
                                 COUNTERPARTY.equals(tilegnetBuc.getInstitusjonsrolle()))
@@ -88,8 +88,10 @@ public class EuxService {
                 .collect(Collectors.toList());
     }
 
-    private boolean filtrerPåLandkode(Institusjon institusjon, String landkode) {
-        return StringUtils.isEmpty(landkode) || landkode.equalsIgnoreCase(institusjon.getLandkode());
+    private boolean filtrerPåLandkoder(Institusjon institusjon, Collection<String> landkoder) {
+        return landkoder.isEmpty() || landkoder.stream()
+                .map(String::toLowerCase)
+                .anyMatch(landkode -> landkode.equals(institusjon.getLandkode().toLowerCase()));
     }
 
     public void opprettOgSendSed(SED sed, String rinaSaksnummer) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
@@ -138,7 +138,7 @@ public class EuxServiceTest {
 
     @Test
     public void hentMottakerinstitusjoner_laBuc04LandSverige_forventEnInstitusjon() {
-        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner(BucType.LA_BUC_04.name(), "SE");
+        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner(BucType.LA_BUC_04.name(), List.of("SE"));
         assertThat(institusjoner).hasSize(1);
         assertThat(institusjoner.get(0).getAkronym()).isEqualTo("FK Sverige-TS70");
         verify(euxConsumer).hentInstitusjoner(eq(BucType.LA_BUC_04.name()), eq(null));
@@ -146,13 +146,13 @@ public class EuxServiceTest {
 
     @Test
     public void hentMottakerinstitusjoner_sBuc18LandSverige_forventIngenInstitusjoner() {
-        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("S_BUC_24", "SE");
+        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("S_BUC_24", List.of("SE"));
         assertThat(institusjoner).isEmpty();
     }
 
     @Test
     public void hentMottakerinstitusjoner_laBuc04LandGB_forventEnInstitusjon() {
-        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("LA_BUC_04", "GB");
+        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("LA_BUC_04", List.of("GB"));
         assertThat(institusjoner).hasSize(1);
 
         Institusjon institusjon = institusjoner.get(0);
@@ -162,7 +162,7 @@ public class EuxServiceTest {
 
     @Test
     public void hentMottakerinstitusjoner_laBuc04LandGR_forventEnInstitusjon() {
-        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("LA_BUC_04", "GR");
+        List<Institusjon> institusjoner = euxService.hentMottakerinstitusjoner("LA_BUC_04", List.of("GR"));
         assertThat(institusjoner).hasSize(1);
 
         Institusjon institusjon = institusjoner.get(0);


### PR DESCRIPTION
Krever tilsvarende endringer i `melosys-api`. Formålet er å unngå flere API-kall i `melosys-web` eller `melosys-api` for å hente ut liste med mottakerinstitusjoner for alle valgte land.