### PR TITLE
Mottak X-SED uten sakstilknytning i Melosys

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/SedType.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/SedType.java
@@ -45,5 +45,9 @@ public enum SedType {
     H130,
 
     S040,
-    S041
+    S041;
+
+    public boolean erXSED() {
+        return this.name().startsWith("X");
+    }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/SED.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/SED.java
@@ -2,6 +2,8 @@
 package no.nav.melosys.eessi.models.sed;
 
 
+import java.util.Optional;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -9,8 +11,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import lombok.Data;
+import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.sed.medlemskap.Medlemskap;
-import no.nav.melosys.eessi.models.sed.nav.Nav;
+import no.nav.melosys.eessi.models.sed.nav.*;
 
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -29,4 +32,15 @@ public class SED {
     private String sedGVer;
 
     private String sedVer;
+
+    public Optional<Person> finnPerson() {
+        return erXSED()
+                ? Optional.ofNullable(nav.getSak()).map(Sak::getKontekst).map(Kontekst::getBruker).map(Bruker::getPerson)
+                : Optional.of(nav.getBruker().getPerson());
+
+    }
+
+    public boolean erXSED() {
+        return SedType.valueOf(sedType).erXSED();
+    }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonKontroller.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonKontroller.java
@@ -38,8 +38,9 @@ class PersonKontroller {
         dateFormatter.setTimeZone(tpsFoedselsdatoCalendar.getTimeZone());
 
         String tpsFoedselsdato = dateFormatter.format(tpsFoedselsdatoCalendar.getTime());
-        String sedFoedselsdato = sed.getNav().getBruker().getPerson().getFoedselsdato().substring(0, LOCAL_DATE_LENGTH);
 
-        return tpsFoedselsdato.equalsIgnoreCase(sedFoedselsdato);
+        return sed.finnPerson().map(no.nav.melosys.eessi.models.sed.nav.Person::getFoedselsdato)
+                .map(dato -> dato.substring(0, LOCAL_DATE_LENGTH))
+                .stream().anyMatch(tpsFoedselsdato::equalsIgnoreCase);
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonSok.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonSok.java
@@ -63,7 +63,7 @@ class PersonSok {
     private SoekBegrunnelse vurderPerson(Person person, SED sed) {
         if (erOpphoert(person)) {
             return SoekBegrunnelse.PERSON_OPPHORT;
-        } else if (!harSammeStatsborgerskap(person, sed)) {
+        } else if (!sed.erXSED() && !harSammeStatsborgerskap(person, sed)) {
             return SoekBegrunnelse.FEIL_STATSBORGERSKAP;
         } else if (!harSammeFoedselsdato(person, sed)) {
             return SoekBegrunnelse.FEIL_FOEDSELSDATO;
@@ -79,7 +79,10 @@ class PersonSok {
      * @return fødselsnummer/d-nummer for person, null hvis ikke funnet
      */
     private List<PersonSoekResponse> søkEtterPerson(SED sed) {
-        no.nav.melosys.eessi.models.sed.nav.Person sedPerson = sed.getNav().getBruker().getPerson();
+        return sed.finnPerson().map(this::søkEtterPerson).orElse(Collections.emptyList());
+    }
+
+    private List<PersonSoekResponse> søkEtterPerson(no.nav.melosys.eessi.models.sed.nav.Person sedPerson) {
         LocalDate foedselsdato = tilLocalDate(sedPerson.getFoedselsdato());
 
         List<PersonSoekResponse> response;

--- a/melosys-eessi-app/src/test/resources/mock/sedX001.json
+++ b/melosys-eessi-app/src/test/resources/mock/sedX001.json
@@ -17,7 +17,7 @@
             "kjoenn": "M",
             "fornavn": "asdsdjoiuo",
             "etternavn": "asd asdsd",
-            "foedselsdato": "asd iojoijioo"
+            "foedselsdato": "2000-01-01"
           }
         }
       }


### PR DESCRIPTION
Fiks for å kunne opprette journalpost av en X-SED, hvor det ikke er opprettet en sak av tilhørende BUC enda. Disse har til nå feilet med en nullpointer, og blitt restartet manuelt etter en sak har blitt opprettet.

Sjekker ikke statsborgerskap ved identifisering av en X-SED, da dette ikke er mulig å oppgi her. Ved jfr-oppgave for en X-SED vil uansett en saksbehandler måtte gå inn og behandle den.