### PR TITLE
Bugfix - Støtter mapping av statsløst statsborgerskap

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -17,8 +17,7 @@ public final class LandkodeMapper {
 
     static {
         Arrays.stream(Locale.getISOCountries()).forEach(c -> map.put(new Locale("", c).getISO3Country(), c));
-        //FIXME: midlertidig fix for landkoder utenfor iso-standard til vi blir enige om hvilke som skal brukes
-        map.put("XXX", "XXX"); //Statsløs
+        map.put("XXX", "XS"); //Statsløs
         map.put("???", "???"); //Ukjent
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
@@ -31,6 +31,6 @@ public class LandkodeMapperTest {
     @Test
     public void getIso2_medIkkeISOStandardKoder_forventSammeKodeTilbake() throws NotFoundException {
         assertThat(LandkodeMapper.getLandkodeIso2("???")).isEqualTo("???");
-        assertThat(LandkodeMapper.getLandkodeIso2("XXX")).isEqualTo("XXX");
+        assertThat(LandkodeMapper.getLandkodeIso2("XXX")).isEqualTo("XS");
     }
 }


### PR DESCRIPTION
Iso3 -> Iso2 for statsløs mappes XXX -> XS (XS brukes av RINA)

Hører sammen med fiks i melosys-api: https://github.com/navikt/melosys-api/pull/423