### PR TITLE
MELOSYS-4411:  hentPerson mapping

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLQuery.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLQuery.java
@@ -6,21 +6,42 @@ final class PDLQuery {
 
     static final String HENT_PERSON_QUERY = """
             query($ident: ID!) {
-                hentPerson(ident: $ident) {
-                    navn {
-                        fornavn
-                        etternavn
-                    }
-                    foedsel {
-                        foedselsdato
-                    }
-                    statsborgerskap {
-                        land
-                    }
-                    folkeregisterpersonstatus {
-                        status
-                    }
-                }
-            }
+               hentPerson(ident: $ident) {
+                 navn {
+                     fornavn
+                     etternavn
+                     metadata {
+                         master
+                         endringer {
+                             registrert
+                             type
+                         }
+                     }
+                 }
+                 foedsel {
+                     foedselsdato
+                     metadata {
+                         master
+                         endringer {
+                             registrert
+                             type
+                         }
+                     }
+                 }
+                 statsborgerskap {
+                     land
+                 }
+                 folkeregisterpersonstatus {
+                     status
+                     metadata {
+                         master
+                         endringer {
+                             registrert
+                             type
+                         }
+                     }
+                 }
+               }
+             }
             """;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLService.java
@@ -1,22 +1,53 @@
 package no.nav.melosys.eessi.integration.pdl;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import no.nav.melosys.eessi.integration.PersonFasade;
+import no.nav.melosys.eessi.integration.pdl.dto.PDLStatsborgerskap;
 import no.nav.melosys.eessi.models.person.PersonModell;
+import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
 import no.nav.melosys.eessi.service.tps.personsok.PersonSoekResponse;
 import no.nav.melosys.eessi.service.tps.personsok.PersonsoekKriterier;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Component;
+
+import static no.nav.melosys.eessi.integration.pdl.PDLUtils.hentSisteOpplysning;
 
 @Component
 public class PDLService implements PersonFasade {
 
     private static final String IKKE_IMPLEMENTERT = "Ikke implementert";
 
+    private final PDLConsumer pdlConsumer;
+
+    public PDLService(PDLConsumer pdlConsumer) {
+        this.pdlConsumer = pdlConsumer;
+    }
+
     @Override
     public PersonModell hentPerson(String ident) {
-        throw new NotImplementedException(IKKE_IMPLEMENTERT);
+        var pdlPerson = pdlConsumer.hentPerson(ident);
+
+        var personModellBuilder = PersonModell.builder().ident(ident);
+
+        hentSisteOpplysning(pdlPerson.getNavn()).ifPresent(navn -> {
+            personModellBuilder.fornavn(navn.getFornavn());
+            personModellBuilder.etternavn(navn.getEtternavn());
+        });
+
+        hentSisteOpplysning(pdlPerson.getFoedsel())
+                .ifPresent(fødsel -> personModellBuilder.fødselsdato(fødsel.getFoedselsdato()));
+        hentSisteOpplysning(pdlPerson.getFolkeregisterpersonstatus())
+                .ifPresent(status -> personModellBuilder.erOpphørt(status.statusErOpphørt()));
+        personModellBuilder.statsborgerskapLandkodeISO2(
+                pdlPerson.getStatsborgerskap().stream()
+                .map(PDLStatsborgerskap::getLand)
+                .map(LandkodeMapper::getLandkodeIso2)
+                .collect(Collectors.toSet())
+        );
+
+        return personModellBuilder.build();
     }
 
     @Override

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLUtils.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLUtils.java
@@ -1,0 +1,18 @@
+package no.nav.melosys.eessi.integration.pdl;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+
+import no.nav.melosys.eessi.integration.pdl.dto.HarMetadata;
+
+final class PDLUtils {
+
+    private PDLUtils() {}
+
+    static <T extends HarMetadata> Optional<T> hentSisteOpplysning(Collection<T> opplysning) {
+        return opplysning.stream().max(sistEndretComparator);
+    }
+
+    private static final Comparator<HarMetadata> sistEndretComparator = Comparator.comparing(harMetadata -> harMetadata.getMetadata().sisteDatoOpprettetEllerKorrigert());
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/HarMetadata.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/HarMetadata.java
@@ -1,0 +1,5 @@
+package no.nav.melosys.eessi.integration.pdl.dto;
+
+public interface HarMetadata {
+    PDLMetadata getMetadata();
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLEndring.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLEndring.java
@@ -2,9 +2,13 @@ package no.nav.melosys.eessi.integration.pdl.dto;
 
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class PDLEndring {
     private String type;
     private LocalDateTime registrert;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLEndring.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLEndring.java
@@ -1,0 +1,18 @@
+package no.nav.melosys.eessi.integration.pdl.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class PDLEndring {
+    private String type;
+    private LocalDateTime registrert;
+
+    private static final String ENDRINGSTYPE_OPPRETT = "OPPRETT";
+    private static final String ENDRINGSTYPE_KORRIGER = "KORRIGER";
+
+    public boolean erOpprettelseEllerKorrigering() {
+        return ENDRINGSTYPE_OPPRETT.equals(type) || ENDRINGSTYPE_KORRIGER.equals(type);
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLFoedsel.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLFoedsel.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import lombok.Data;
 
 @Data
-public class PDLFoedsel {
+public class PDLFoedsel implements HarMetadata {
     private LocalDate foedselsdato;
+    private PDLMetadata metadata;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLFolkeregisterPersonstatus.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLFolkeregisterPersonstatus.java
@@ -3,6 +3,14 @@ package no.nav.melosys.eessi.integration.pdl.dto;
 import lombok.Data;
 
 @Data
-public class PDLFolkeregisterPersonstatus {
+public class PDLFolkeregisterPersonstatus implements HarMetadata {
+
+    private static final String STATUS_OPPHØRT = "opphoert";
+
     private String status;
+    private PDLMetadata metadata;
+
+    public boolean statusErOpphørt() {
+        return STATUS_OPPHØRT.equals(status);
+    }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLMetadata.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLMetadata.java
@@ -1,0 +1,23 @@
+package no.nav.melosys.eessi.integration.pdl.dto;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+
+import lombok.Data;
+
+@Data
+public class PDLMetadata {
+    private String opplysningsId;
+    private String master;
+    private Collection<PDLEndring> endringer = Collections.emptyList();
+    private boolean historisk;
+
+    public LocalDateTime sisteDatoOpprettetEllerKorrigert() {
+        return endringer.stream()
+                .filter(PDLEndring::erOpprettelseEllerKorrigering)
+                .map(PDLEndring::getRegistrert)
+                .max(LocalDateTime::compareTo)
+                .orElse(LocalDateTime.MIN);
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLNavn.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLNavn.java
@@ -3,7 +3,8 @@ package no.nav.melosys.eessi.integration.pdl.dto;
 import lombok.Data;
 
 @Data
-public class PDLNavn {
+public class PDLNavn implements HarMetadata {
     private String fornavn;
     private String etternavn;
+    private PDLMetadata metadata;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/tps/TpsService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/tps/TpsService.java
@@ -3,6 +3,7 @@ package no.nav.melosys.eessi.integration.tps;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -75,14 +76,19 @@ public class TpsService implements PersonFasade {
                                 )
                 );
 
-        return new PersonModell(
-                ident,
-                res.getPersonnavn().getFornavn(),
-                res.getPersonnavn().getEtternavn(),
-                tilLocalDate(res.getFoedselsdato().getFoedselsdato()),
-                LandkodeMapper.getLandkodeIso2(res.getStatsborgerskap().getLand().getValue()),
-                Arrays.asList(UTGAATT_PERSON_ANNULLERT_TILGANG, UTGAATT_PERSON)
-                        .contains(res.getPersonstatus().getPersonstatus().getValue()));
+        return PersonModell.builder()
+                .ident(ident)
+                .fornavn(res.getPersonnavn().getFornavn())
+                .etternavn(res.getPersonnavn().getEtternavn())
+                .fødselsdato(tilLocalDate(res.getFoedselsdato().getFoedselsdato()))
+                .statsborgerskapLandkodeISO2(
+                        Collections.singleton(LandkodeMapper.getLandkodeIso2(res.getStatsborgerskap().getLand().getValue()))
+                )
+                .erOpphørt(
+                        Arrays.asList(UTGAATT_PERSON_ANNULLERT_TILGANG, UTGAATT_PERSON)
+                                .contains(res.getPersonstatus().getPersonstatus().getValue())
+                )
+                .build();
     }
 
     private Person hentPerson(HentPersonRequest request) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/person/PersonModell.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/person/PersonModell.java
@@ -1,17 +1,21 @@
 package no.nav.melosys.eessi.models.person;
 
 import java.time.LocalDate;
+import java.util.Collection;
 
+import lombok.Builder;
 import lombok.Value;
 
 @Value
+@Builder
 public class PersonModell {
     String ident;
     String fornavn;
     String etternavn;
     LocalDate fødselsdato;
-    String statsborgerskapLandkodeISO2;
+    Collection<String> statsborgerskapLandkodeISO2;
     //TPS: status UTPE (utgått) eller UTAN (utgått annullert tilgang)
-    //PDL: status "opphoert" eller "ikkeBosatt" (sistnevnte svarer også til UREG i TPS)
+    //PDL: status "opphoert" svarer til UTPE i TPS
+    // "ikkeBosatt" svarer til UREG i TPS men har også flere betydninger og vil ikke brukes her
     boolean erOpphørt;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonKontroller.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonKontroller.java
@@ -1,7 +1,7 @@
 package no.nav.melosys.eessi.service.identifisering;
 
 import java.time.LocalDate;
-import java.util.stream.Stream;
+import java.util.Collection;
 
 import lombok.experimental.UtilityClass;
 import no.nav.melosys.eessi.models.person.PersonModell;
@@ -14,11 +14,11 @@ class PersonKontroller {
     private static final int LOCAL_DATE_LENGTH = 10;
 
     static boolean harSammeStatsborgerskap(PersonModell person, SED sed) {
-        String tpsStatsborgerskap = person.getStatsborgerskapLandkodeISO2();
-        Stream<String> sedStatsborgerskap = sed.getNav().getBruker().getPerson().getStatsborgerskap()
-                .stream().map(Statsborgerskap::getLand);
+        Collection<String> registerStatsborgerskap = person.getStatsborgerskapLandkodeISO2();
 
-        return sedStatsborgerskap.anyMatch(tpsStatsborgerskap::equalsIgnoreCase);
+        return sed.getNav().getBruker().getPerson().getStatsborgerskap()
+                .stream().map(Statsborgerskap::getLand)
+                .anyMatch(registerStatsborgerskap::contains);
     }
 
     static boolean harSammeFoedselsdato(PersonModell person, SED sed) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/PDLServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/PDLServiceTest.java
@@ -1,0 +1,103 @@
+package no.nav.melosys.eessi.integration.pdl;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import no.nav.melosys.eessi.integration.pdl.dto.*;
+import no.nav.melosys.eessi.models.person.PersonModell;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PDLServiceTest {
+
+    @Mock
+    private PDLConsumer pdlConsumer;
+
+    private PDLService pdlService;
+
+    @BeforeEach
+    public void setup() {
+        pdlService = new PDLService(pdlConsumer);
+    }
+
+    @Test
+    void hentPerson_personMedFlereEndringerPåNavnFlereStatsborgerskap_nyesteEndringerForNavnAlleStatsborgerskapMappes() {
+        final String ident = "12345600000";
+
+        when(pdlConsumer.hentPerson(eq(ident))).thenReturn(lagPersonMedFlereEndringer());
+        assertThat(pdlService.hentPerson(ident))
+                .extracting(
+                        PersonModell::getIdent,
+                        PersonModell::getFornavn,
+                        PersonModell::getEtternavn,
+                        PersonModell::getFødselsdato,
+                        PersonModell::getStatsborgerskapLandkodeISO2,
+                        PersonModell::isErOpphørt)
+                .containsExactly(
+                        ident,
+                        "NyttFornavn",
+                        "NyttEtternavn",
+                        LocalDate.of(1990, 1, 1),
+                        Set.of("NO", "SE", "PL"),
+                        false);
+    }
+
+    private PDLPerson lagPersonMedFlereEndringer() {
+        var pdlPerson = new PDLPerson();
+
+        var gammeltPdlNavn = new PDLNavn();
+        gammeltPdlNavn.setFornavn("GammeltFornavn");
+        gammeltPdlNavn.setEtternavn("GammeltEtternavn");
+        gammeltPdlNavn.setMetadata(new PDLMetadata());
+        gammeltPdlNavn.getMetadata().setEndringer(Set.of(
+                new PDLEndring("OPPRETT", LocalDateTime.of(2015, 1, 1, 0, 0))
+        ));
+
+        var nyttPdlNavn = new PDLNavn();
+        nyttPdlNavn.setFornavn("NyttFornavn");
+        nyttPdlNavn.setEtternavn("NyttEtternavn");
+        nyttPdlNavn.setMetadata(new PDLMetadata());
+        nyttPdlNavn.getMetadata().setEndringer(Set.of(
+                new PDLEndring("OPPRETT", LocalDateTime.of(2010, 1, 1, 0, 0)),
+                new PDLEndring("KORRIGER", LocalDateTime.of(2020, 1, 1, 0, 0))
+        ));
+
+        var pdlFødsel = new PDLFoedsel();
+        pdlFødsel.setFoedselsdato(LocalDate.of(1990, 1, 1));
+        pdlFødsel.setMetadata(new PDLMetadata());
+        pdlFødsel.getMetadata().setEndringer(Set.of(
+                new PDLEndring("OPPRETT", LocalDateTime.of(1990, 1, 1, 0, 0))
+        ));
+
+        var norskStatsborgerskap = new PDLStatsborgerskap();
+        norskStatsborgerskap.setLand("NOR");
+
+        var svenskStatsborgerskap = new PDLStatsborgerskap();
+        svenskStatsborgerskap.setLand("SWE");
+
+        var polskStatsborgerskap = new PDLStatsborgerskap();
+        polskStatsborgerskap.setLand("POL");
+
+        var pdlPersonstatus = new PDLFolkeregisterPersonstatus();
+        pdlPersonstatus.setStatus("bosatt");
+        pdlPersonstatus.setMetadata(new PDLMetadata());
+        pdlPersonstatus.getMetadata().setEndringer(Set.of(
+                new PDLEndring("OPPRETT", LocalDateTime.of(2009, 1, 1, 0, 0))
+        ));
+
+        pdlPerson.setNavn(Set.of(gammeltPdlNavn, nyttPdlNavn));
+        pdlPerson.setFoedsel(Set.of(pdlFødsel));
+        pdlPerson.setStatsborgerskap(Set.of(norskStatsborgerskap, svenskStatsborgerskap, polskStatsborgerskap));
+        pdlPerson.setFolkeregisterpersonstatus(Set.of(pdlPersonstatus));
+        return pdlPerson;
+    }
+}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/identifisering/PersonSokTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/identifisering/PersonSokTest.java
@@ -4,9 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.time.LocalDate;
 import java.util.Collections;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -203,22 +201,13 @@ class PersonSokTest {
     }
 
     private PersonModell lagPersonModell(boolean erOpphørt) {
-        return new PersonModell(
-                IDENT,
-                "Fornavn",
-                "Etternavn",
-                LocalDate.parse("1983-05-01"),
-                "NO",
-                erOpphørt
-        );
-    }
-
-
-    /**
-     * @param dato format: yyyy-MM-dd
-     */
-    private XMLGregorianCalendar lagXmlDato(String dato) throws DatatypeConfigurationException {
-        return DatatypeFactory.newInstance()
-                .newXMLGregorianCalendar(dato);
+        return PersonModell.builder()
+                .ident(IDENT)
+                .fornavn("Fornavn")
+                .etternavn("Etternavn")
+                .fødselsdato(LocalDate.parse("1983-05-01"))
+                .statsborgerskapLandkodeISO2(List.of("NO"))
+                .erOpphørt(erOpphørt)
+                .build();
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/tps/TpsServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/tps/TpsServiceTest.java
@@ -1,6 +1,7 @@
 package no.nav.melosys.eessi.service.tps;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import javax.xml.datatype.DatatypeFactory;
 
@@ -58,17 +59,16 @@ class TpsServiceTest {
     void hentPerson_expectPerson() throws HentPersonPersonIkkeFunnet, HentPersonSikkerhetsbegrensning {
         when(personConsumer.hentPerson(any())).thenReturn(hentPersonResponse);
         PersonModell person = tpsService.hentPerson("11223344556");
-        assertThat(person).isNotNull()
-                .isEqualTo(
-                        new PersonModell(
-                                "11223344556",
-                                "Fornavn",
-                                "Etternavn",
-                                LocalDate.parse("2000-01-01"),
-                                "SE",
-                                false
-                        )
-                );
+        assertThat(person).isEqualTo(
+                PersonModell.builder()
+                        .ident("11223344556")
+                        .fornavn("Fornavn")
+                        .etternavn("Etternavn")
+                        .fødselsdato(LocalDate.parse("2000-01-01"))
+                        .statsborgerskapLandkodeISO2(Collections.singleton("SE"))
+                        .erOpphørt(false)
+                        .build()
+        );
     }
 
     @Test

--- a/melosys-eessi-app/src/test/resources/mock/pdl_hent_person.json
+++ b/melosys-eessi-app/src/test/resources/mock/pdl_hent_person.json
@@ -4,12 +4,32 @@
       "navn": [
         {
           "fornavn": "RASK",
-          "etternavn": "MASKIN"
+          "etternavn": "MASKIN",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false,
+            "endringer": [
+              {
+                "registrert": "2020-06-04T18:50:15",
+                "type": "OPPRETT"
+              }
+            ]
+          }
         }
       ],
       "foedsel": [
         {
-          "foedselsdato": "1984-06-25"
+          "foedselsdato": "1984-06-25",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false,
+            "endringer": [
+              {
+                "registrert": "2020-06-04T18:50:15",
+                "type": "OPPRETT"
+              }
+            ]
+          }
         }
       ],
       "statsborgerskap": [
@@ -19,7 +39,17 @@
       ],
       "folkeregisterpersonstatus": [
         {
-          "status": "bosatt"
+          "status": "bosatt",
+          "metadata": {
+            "master": "Freg",
+            "historisk": false,
+            "endringer": [
+              {
+                "registrert": "2020-06-04T18:50:16",
+                "type": "OPPRETT"
+              }
+            ]
+          }
         }
       ]
     }


### PR DESCRIPTION
Henter ut siste opplysning fra responsen til PDL.hentPerson ved å se på metadataen til ønsket opplysning. Har her gjort en antagelse om at hvis en opplysning har en endring med type "OPPHOER" så vil ikke denne opplysningen komme med i responsen, da vi ikke spør om historikk. Har enda til gode å få testet eller bekreftet dette på en annen måte.

EDIT: fikk avklart i #mfn på Slack, var som jeg antok 🙂 