### PR TITLE
Melosys 4440 pdl hent identer

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLConsumer.java
@@ -9,8 +9,7 @@ import no.nav.melosys.eessi.models.exception.IntegrationException;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import static no.nav.melosys.eessi.integration.pdl.PDLQuery.HENT_PERSON_QUERY;
-import static no.nav.melosys.eessi.integration.pdl.PDLQuery.SØK_PERSON_QUERY;
+import static no.nav.melosys.eessi.integration.pdl.PDLQuery.*;
 
 public class PDLConsumer {
 
@@ -46,6 +45,19 @@ public class PDLConsumer {
 
         håndterFeil(res);
         return res.getData().getSokPerson();
+    }
+
+    public PDLIdentliste hentIdenter(String ident) {
+        var request = new GraphQLRequest(HENT_IDENTER_QUERY, Map.of(IDENT_KEY, ident));
+
+        var res = webClient.post()
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<GraphQLResponse<PDLHentIdenterResponse>>() {})
+                .block();
+
+        håndterFeil(res);
+        return res.getData().getHentIdenter();
     }
 
     private void håndterFeil(GraphQLResponse<?> res) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLQuery.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLQuery.java
@@ -62,5 +62,15 @@ final class PDLQuery {
             }
             """;
 
+    static final String HENT_IDENTER_QUERY = """
+            query($ident: ID!) {
+              hentIdenter(ident: $ident) {
+                  identer {
+                      ident,
+                      gruppe
+                  }
+              }
+            }
+            """;
 
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/PDLService.java
@@ -7,11 +7,11 @@ import java.util.stream.Collectors;
 
 import no.nav.melosys.eessi.integration.PersonFasade;
 import no.nav.melosys.eessi.integration.pdl.dto.*;
+import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.person.PersonModell;
 import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
 import no.nav.melosys.eessi.service.tps.personsok.PersonSoekResponse;
 import no.nav.melosys.eessi.service.tps.personsok.PersonsoekKriterier;
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Component;
 
 import static no.nav.melosys.eessi.integration.pdl.PDLUtils.hentSisteOpplysning;
@@ -19,8 +19,6 @@ import static no.nav.melosys.eessi.integration.pdl.dto.PDLSokCriteria.*;
 
 @Component
 public class PDLService implements PersonFasade {
-
-    private static final String IKKE_IMPLEMENTERT = "Ikke implementert";
 
     private final PDLConsumer pdlConsumer;
 
@@ -55,12 +53,22 @@ public class PDLService implements PersonFasade {
 
     @Override
     public String hentAktoerId(String ident) {
-        throw new NotImplementedException(IKKE_IMPLEMENTERT);
+        return pdlConsumer.hentIdenter(ident).getIdenter()
+                .stream()
+                .filter(PDLIdent::erAktørID)
+                .findFirst()
+                .map(PDLIdent::getIdent)
+                .orElseThrow(() -> new NotFoundException("Finner ikke aktørID!"));
     }
 
     @Override
     public String hentNorskIdent(String aktoerID) {
-        throw new NotImplementedException(IKKE_IMPLEMENTERT);
+        return pdlConsumer.hentIdenter(aktoerID).getIdenter()
+                .stream()
+                .filter(PDLIdent::erFolkeregisterIdent)
+                .findFirst()
+                .map(PDLIdent::getIdent)
+                .orElseThrow(() -> new NotFoundException("Finner ikke folkeregisterident!"));
     }
 
     @Override

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLHentIdenterResponse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLHentIdenterResponse.java
@@ -1,0 +1,8 @@
+package no.nav.melosys.eessi.integration.pdl.dto;
+
+import lombok.Data;
+
+@Data
+public class PDLHentIdenterResponse {
+    private PDLIdentliste hentIdenter;
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLIdent.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLIdent.java
@@ -14,4 +14,12 @@ public class PDLIdent {
     public boolean erFolkeregisterIdent() {
         return "FOLKEREGISTERIDENT".equals(gruppe);
     }
+
+    public boolean erAktørID() {
+        return "AKTORID".equals(gruppe);
+    }
+
+    public boolean erNPID() { //NAV PersonIdent
+        return "NPID".equals(gruppe);
+    }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLIdentliste.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLIdentliste.java
@@ -1,0 +1,10 @@
+package no.nav.melosys.eessi.integration.pdl.dto;
+
+import java.util.Collection;
+
+import lombok.Data;
+
+@Data
+public class PDLIdentliste {
+    private Collection<PDLIdent> identer;
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/tps/TpsService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/tps/TpsService.java
@@ -63,6 +63,7 @@ public class TpsService implements PersonFasade {
         this.personsokConsumer = personsokConsumer;
     }
 
+    @Override
     public PersonModell hentPerson(String ident) {
         var res =
                 hentPerson(
@@ -103,14 +104,17 @@ public class TpsService implements PersonFasade {
         return response.getPerson();
     }
 
+    @Override
     public String hentAktoerId(String ident) {
         return aktoerConsumer.hentAktoerId(ident);
     }
 
+    @Override
     public String hentNorskIdent(String aktoerID) {
         return aktoerConsumer.hentNorskIdent(aktoerID);
     }
 
+    @Override
     public List<PersonSoekResponse> soekEtterPerson(PersonsoekKriterier personsoekKriterier) {
 
         FinnPersonRequest request = new FinnPersonRequest();

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/PDLConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/PDLConsumerTest.java
@@ -84,6 +84,20 @@ class PDLConsumerTest {
                 );
     }
 
+    @Test
+    void hentIdentliste_medIdent_mottarOgMapperResponseUtenFeil() {
+        mockServer.enqueue(
+                new MockResponse()
+                .setBody(hentFil("mock/pdl_hent_identliste.json"))
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        assertThat(pdlConsumer.hentIdenter("123").getIdenter())
+                .hasSize(2)
+                .flatExtracting(PDLIdent::getIdent, PDLIdent::getGruppe)
+                .containsExactlyInAnyOrder("28026522600", "FOLKEREGISTERIDENT", "2834873315250", "AKTORID");
+    }
+
     @SneakyThrows
     private String hentFil(String filnavn) {
         return Files.readString(

--- a/melosys-eessi-app/src/test/resources/mock/pdl_hent_identliste.json
+++ b/melosys-eessi-app/src/test/resources/mock/pdl_hent_identliste.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "hentIdenter": {
+      "identer": [
+        {
+          "ident": "28026522600",
+          "gruppe": "FOLKEREGISTERIDENT"
+        },
+        {
+          "ident": "2834873315250",
+          "gruppe": "AKTORID"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Implementasjon av PDL sin hentIdenter-spørring.

Spørringen tar i mot hvilken som helst ID som input. Så det spiller ingen rolle om vi spør om alle identer basert på en aktørid, fnr, dnr eller NPID (NAV-PersonID) som input til tjenesten. Dette gjelder for øvrig alle PDL-tjenester.