### PR TITLE
Håndterer mottak av SED hvor norsk ident er oppgitt i feil format

### DIFF
--- a/melosys-eessi-app/pom.xml
+++ b/melosys-eessi-app/pom.xml
@@ -134,6 +134,11 @@
             <version>${personsok.version}</version>
         </dependency>
         <dependency>
+            <groupId>no.bekk.bekkopen</groupId>
+            <artifactId>nocommons</artifactId>
+            <version>${bekk-nocommons.version}</version>
+        </dependency>
+        <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-spring</artifactId>
             <version>${shedlock-version}</version>

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/FnrUtils.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/FnrUtils.java
@@ -1,0 +1,26 @@
+package no.nav.melosys.eessi.service.identifisering;
+
+import java.util.Optional;
+
+import no.bekk.bekkopen.person.FodselsnummerValidator;
+
+final class FnrUtils {
+    private FnrUtils() {}
+
+    /**
+     * Tar hensyn til ikke-numeriske tegn oppgitt som ident
+     */
+    static Optional<String> filtrerUtGyldigNorskIdent(String ident) {
+        return Optional.ofNullable(ident)
+                .map(FnrUtils::fjernIkkeNumeriskeTegn)
+                .filter(FnrUtils::erGyldigIdent);
+    }
+
+    static String fjernIkkeNumeriskeTegn(String tekst) {
+        return tekst.replaceAll("[^\\d]", "");
+    }
+
+    private static boolean erGyldigIdent(String ident) {
+        return FodselsnummerValidator.isValid(ident);
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonIdentifiseringService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/identifisering/PersonIdentifiseringService.java
@@ -70,7 +70,10 @@ public class PersonIdentifiseringService {
                 .statsborgerskapISO2(person.getStatsborgerskap().stream().map(Statsborgerskap::getLand).collect(Collectors.toSet()))
                 .build();
 
-        Optional<String> norskIdent = person.finnNorskPin().map(Pin::getIdentifikator).map(String::trim);
+        Optional<String> norskIdent = person.finnNorskPin()
+                .map(Pin::getIdentifikator)
+                .flatMap(FnrUtils::filtrerUtGyldigNorskIdent);
+
         if (norskIdent.isPresent()) {
             PersonSokResultat resultat = tpsPersonSok.vurderPerson(norskIdent.get(), søkeKriterier);
             if (resultat.personIdentifisert()) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/identifisering/FnrUtilsTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/identifisering/FnrUtilsTest.java
@@ -1,0 +1,36 @@
+package no.nav.melosys.eessi.service.identifisering;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FnrUtilsTest {
+
+    @Test
+    void filtrerUtGyldigNorskIdent_nullverdi_tomtResultat() {
+        assertThat(FnrUtils.filtrerUtGyldigNorskIdent(null)).isNotPresent();
+    }
+
+    @Test
+    void filtrerUtGyldigNorskIdent_ikkeGyldigIdent_tomtResultat() {
+        assertThat(FnrUtils.filtrerUtGyldigNorskIdent("123-lala-22")).isNotPresent();
+    }
+
+    @Test
+    void filtrerUtGyldigNorskIdent_gyldigFnrMedBindestrekMellom_returnererKorrektIdent() {
+        assertThat(FnrUtils.filtrerUtGyldigNorskIdent("2506-84-20779 ")).contains("25068420779");
+    }
+
+    @Test
+    void filtrerUtGyldigNorskIdent_gyldigDnrMedIkkeNumeriskeTegnkMellom_returnererKorrektIdent() {
+        assertThat(FnrUtils.filtrerUtGyldigNorskIdent("64068-648....643")).contains("64068648643");
+    }
+
+    @Test
+    void fjernIkkeNumeriskeTegn_medDiverseTegnMellomNummer_fjernerAlleIkkeNumeriske() {
+        assertThat(FnrUtils.fjernIkkeNumeriskeTegn("123321.")).isEqualTo("123321");
+        assertThat(FnrUtils.fjernIkkeNumeriskeTegn("1e2r33-2.1.")).isEqualTo("123321");
+        assertThat(FnrUtils.fjernIkkeNumeriskeTegn("1e2 r33-2.1.")).isEqualTo("123321");
+        assertThat(FnrUtils.fjernIkkeNumeriskeTegn("abc.-?0%#&%$")).isEqualTo("0");
+    }
+}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/identifisering/PersonIdentifiseringServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/identifisering/PersonIdentifiseringServiceTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PersonIdentifiseringServiceTest {
 
+    private final String norskIdent = "64068648643";
+
     @Mock
     private PersonSok personSok;
     @Mock
@@ -54,7 +56,6 @@ class PersonIdentifiseringServiceTest {
 
     @Test
     void identifiserPerson_sakEksisterer_hentPersonFraSak() {
-        final String norskIdent = "333333";
         Sak sak = new Sak();
         sak.setAktoerId("32132132");
 
@@ -71,7 +72,6 @@ class PersonIdentifiseringServiceTest {
 
     @Test
     void identifiserPerson_ingenSakSedMedNorskIdent_personSuksessfultValidert() {
-        final String norskIdent = "333333";
         SED sed = lagSED();
         sed.getNav().getBruker().getPerson().setPin(List.of(new Pin(norskIdent, "NO", null)));
 
@@ -82,7 +82,6 @@ class PersonIdentifiseringServiceTest {
 
     @Test
     void identifiserPerson_ingenSakSedIngenNorskIdent_finnerIkkePersonFraSedFinnerFraSøk() {
-        final String norskIdent = "33";
         when(personSok.søkEtterPerson(any(PersonsokKriterier.class))).thenReturn(PersonSokResultat.identifisert(norskIdent));
         Optional<String> res = personIdentifiseringService.identifiserPerson("123", lagSED());
         assertThat(res).contains(norskIdent);

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestBase.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestBase.java
@@ -45,7 +45,7 @@ public abstract class ComponentTestBase {
 
     static final LocalDate FØDSELSDATO = LocalDate.of(2000, 1, 1);
     static final String STATSBORGERSKAP = "NO";
-    static final String FNR = "01019912345";
+    static final String FNR = "25068420779";
 
     protected final MockData mockData = new MockData();
 

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestIT.java
@@ -43,7 +43,7 @@ class ComponentTestIT extends ComponentTestBase {
         // Venter på to Kafka-meldinger: den vi selv legger på topic som input, og den som kommer som output
         kafkaTestConsumer.reset(2);
         kafkaTemplate.send(createProducerRecord(mockData.sedHendelse(sedID, FNR))).get();
-        kafkaTestConsumer.doWait(2_000L);
+        kafkaTestConsumer.doWait(5_000L);
 
         assertThat(hentRecords()).hasSize(1)
                 .extracting(Object::toString)
@@ -75,7 +75,7 @@ class ComponentTestIT extends ComponentTestBase {
 
         kafkaTestConsumer.reset(2);
         kafkaTemplate.send(createProducerRecord(mockData.sedHendelse(sedID, null))).get();
-        kafkaTestConsumer.doWait(2_000L);
+        kafkaTestConsumer.doWait(5_000L);
 
         assertThat(hentRecords()).hasSize(1);
     }
@@ -91,7 +91,7 @@ class ComponentTestIT extends ComponentTestBase {
 
         kafkaTestConsumer.reset(1);
         kafkaTemplate.send(createProducerRecord(mockData.sedHendelse(sedID, null))).get();
-        kafkaTestConsumer.doWait(2_000L);
+        kafkaTestConsumer.doWait(5_000L);
 
         verify(oppgaveConsumer, timeout(2000)).opprettOppgave(any());
         assertThat(hentRecords()).isEmpty();
@@ -108,7 +108,7 @@ class ComponentTestIT extends ComponentTestBase {
 
         kafkaTestConsumer.reset(1);
         kafkaTemplate.send(createProducerRecord(mockData.sedHendelse(sedID, FNR))).get();
-        kafkaTestConsumer.doWait(2_000L);
+        kafkaTestConsumer.doWait(5_000L);
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> sedMottattRepository.count() > 0);
         assertThat(sedMottattRepository.findAll())

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <description>Melosys EESSI integrasjon</description>
 
     <properties>
+        <bekk-nocommons.version>0.12.0</bekk-nocommons.version>
         <commons-io.version>2.8.0</commons-io.version>
         <cxf.version>3.4.2</cxf.version>
         <guava.version>29.0-jre</guava.version>


### PR DESCRIPTION
Feks når norsk ident er oppgitt med en bindestrek mellom fødselsdato og personnummer.
Legger til en avhengighet `bekk-nocommons` som har validering for norsk ident.