### PR TITLE
MELOSYS-4567 - kopier buc

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -80,7 +80,7 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: deploy/nais.yaml
-          VAR: namespace=q2
+          VAR: namespace=q2,ingress=https://melosys-eessi-q2.dev.adeo.no
 
   # Deploy til Q1 manuelt
   deploy_q1:
@@ -97,7 +97,7 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: deploy/nais.yaml
-          VAR: namespace=default
+          VAR: namespace=default,ingress=https://melosys-eessi-q1.dev.adeo.no
 
   # Deploy til prod manuelt
   deploy_prod:
@@ -114,7 +114,7 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-fss
           RESOURCE: deploy/nais.yaml
-          VAR: namespace=default
+          VAR: namespace=default,ingress=https://melosys-eessi.nais.adeo.no
       - run: |
           echo "COMMIT_MSG=$(git log --format=%s -n 1)" >> $GITHUB_ENV
       - name: Slack Notification (deploy success)

--- a/deploy/nais.yaml
+++ b/deploy/nais.yaml
@@ -35,3 +35,6 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: nais
+  ingresses:
+    - {{ingress}}
+

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/SwaggerConfig.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/SwaggerConfig.java
@@ -2,7 +2,6 @@ package no.nav.melosys.eessi.config;
 
 import java.util.Collections;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
@@ -17,7 +16,6 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
 @EnableSwagger2
-@ConditionalOnProperty(name = "NAIS_CLUSTER_NAME", havingValue = "dev-fss", matchIfMissing = true)
 public class SwaggerConfig {
 
     @Bean

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
@@ -5,9 +5,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import no.nav.melosys.eessi.service.buc.KopierBucService;
+import no.nav.security.token.support.core.api.Protected;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Protected
 @RestController
 public class KopierBucController {
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
@@ -1,0 +1,36 @@
+package no.nav.melosys.eessi.controller;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import no.nav.melosys.eessi.service.buc.KopierBucService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class KopierBucController {
+
+    private final KopierBucService kopierBucService;
+
+    public KopierBucController(KopierBucService kopierBucService) {
+        this.kopierBucService = kopierBucService;
+    }
+
+    @PostMapping("/bucer/kopier")
+    public Map<String, String> kopierOverBUCer(Collection<String> bucer) {
+        var saker = new HashMap<String, String>();
+        for (var rinaSaksnummer : bucer) {
+            String resultat;
+            try {
+                resultat = kopierBucService.kopierBUC(rinaSaksnummer);
+            } catch (Exception e) {
+                resultat = e.getMessage();
+            }
+
+            saker.put(rinaSaksnummer, resultat);
+        }
+
+        return saker;
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.swagger.annotations.ApiOperation;
 import no.nav.melosys.eessi.service.buc.KopierBucService;
 import no.nav.security.token.support.core.api.Protected;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +21,7 @@ public class KopierBucController {
         this.kopierBucService = kopierBucService;
     }
 
+    @ApiOperation("Kopierer over første SED i en BUC til en ny BUC og lagrer saksrelasjon på samme arkivsak som tidligere BUC")
     @PostMapping("/bucer/kopier")
     public Map<String, String> kopierOverBUCer(@RequestBody Collection<String> bucer) {
         var saker = new HashMap<String, String>();

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KopierBucController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import no.nav.melosys.eessi.service.buc.KopierBucService;
 import no.nav.security.token.support.core.api.Protected;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Protected
@@ -20,7 +21,7 @@ public class KopierBucController {
     }
 
     @PostMapping("/bucer/kopier")
-    public Map<String, String> kopierOverBUCer(Collection<String> bucer) {
+    public Map<String, String> kopierOverBUCer(@RequestBody Collection<String> bucer) {
         var saker = new HashMap<String, String>();
         for (var rinaSaksnummer : bucer) {
             String resultat;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
@@ -1,10 +1,9 @@
 package no.nav.melosys.eessi.models.buc;
 
 import java.time.ZonedDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -32,6 +31,8 @@ public class BUC {
     private String bucType;
     @JsonProperty(value = "processDefinitionVersion")
     private String bucVersjon;
+    private Collection<Participant> participants;
+    private String internationalId;
 
     public boolean kanOppretteEllerOppdatereSed(SedType sedType) {
         return actions.stream().anyMatch(action ->
@@ -107,5 +108,12 @@ public class BUC {
                 .filter(Document::erOpprettet)
                 .filter(documentPredicate)
                 .max(Comparator.comparing(Document::getLastUpdate));
+    }
+
+    public Set<String> hentMottakere() {
+        return participants.stream()
+                .filter(Participant::erMotpart)
+                .map(p -> p.getOrganisation().getId())
+                .collect(Collectors.toSet());
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/Participant.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/Participant.java
@@ -18,10 +18,16 @@ public class Participant {
         @JsonProperty("Participant")
         DELTAKER,
         @JsonProperty("CounterParty")
-        MOTPART
+        MOTPART,
+        @JsonProperty("CaseOwner")
+        SAKSEIER
     }
 
     private ParticipantRole role;
     private Organisation organisation;
+
+    public boolean erMotpart() {
+        return role == ParticipantRole.MOTPART;
+    }
 }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/buc/KopierBucService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/buc/KopierBucService.java
@@ -1,0 +1,69 @@
+package no.nav.melosys.eessi.service.buc;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.NoSuchElementException;
+
+import no.nav.melosys.eessi.models.BucType;
+import no.nav.melosys.eessi.models.buc.Document;
+import no.nav.melosys.eessi.models.sed.SED;
+import no.nav.melosys.eessi.service.eux.EuxService;
+import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
+import org.springframework.stereotype.Service;
+
+import static java.util.Optional.ofNullable;
+
+@Service
+public class KopierBucService {
+
+    private static final int MAKS_LENGDE_YTTERLIGERE_INFO = 498; //500 minus to "\n"
+
+    private final EuxService euxService;
+    private final SaksrelasjonService saksrelasjonService;
+
+    public KopierBucService(EuxService euxService, SaksrelasjonService saksrelasjonService) {
+        this.euxService = euxService;
+        this.saksrelasjonService = saksrelasjonService;
+    }
+
+    public String kopierBUC(String rinaSaksnummer) {
+        var buc = euxService.hentBuc(rinaSaksnummer);
+        var bucType = BucType.valueOf(buc.getBucType());
+        var førsteSEDType = bucType.hentFørsteLovligeSed();
+
+        var sed = buc.getDocuments().stream()
+                .filter(d -> førsteSEDType.name().equals(d.getType()))
+                .filter(Document::erOpprettet)
+                .min(Comparator.comparing(Document::getCreationDate))
+                .map(d -> euxService.hentSed(rinaSaksnummer, d.getId()))
+                .orElseThrow(() -> new NoSuchElementException("Finner ikke første SED for rinasak " + rinaSaksnummer));
+
+        settYtterligereInfo(sed, buc.getInternationalId());
+        var nyttRinaSaksnummer = euxService.opprettBucOgSed(bucType, buc.hentMottakere(), sed, Collections.emptySet()).getRinaSaksnummer();
+
+        saksrelasjonService.finnVedRinaSaksnummer(rinaSaksnummer)
+                .ifPresent(saksrelasjon -> saksrelasjonService.lagreKobling(saksrelasjon.getGsakSaksnummer(), nyttRinaSaksnummer, bucType));
+
+        return nyttRinaSaksnummer;
+    }
+
+    private void settYtterligereInfo(SED sed, String internasjonalID) {
+        final var infoTekst = hentInfoTekst(sed.getSedType(), internasjonalID);
+        final var ytterligereInfo = ofNullable(sed.getNav().getYtterligereinformasjon()).orElse("");
+
+        if ((ytterligereInfo.length() + infoTekst.length()) > MAKS_LENGDE_YTTERLIGERE_INFO) {
+            sed.getNav().setYtterligereinformasjon(infoTekst);
+        } else {
+            sed.getNav().setYtterligereinformasjon(ytterligereInfo + "\n\n" + infoTekst);
+        }
+    }
+
+    private String hentInfoTekst(String sedType, String internasjonalID) {
+        return String.format("""
+                Due to an error in Rina, we are sending you a new %s.
+                This BUC replaces a previously sent BUC with International ID: %s.
+                We are unable to read your reply to our %s in the original BUC.
+                Please reply in this BUC. We apologize for any inconvenience this may have caused.
+                """, sedType, internasjonalID, sedType);
+    }
+}

--- a/melosys-eessi-app/src/main/resources/application.yml
+++ b/melosys-eessi-app/src/main/resources/application.yml
@@ -88,3 +88,4 @@ no.nav.security.jwt.issuer:
   isso:
     discovery-url: ${ISSO_URL}/.well-known/openid-configuration
     accepted-audience: ${ISSO_ACCEPTED_AUDIENCE}
+    cookie-name: ID_token

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/buc/KopierBucServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/buc/KopierBucServiceTest.java
@@ -1,0 +1,85 @@
+package no.nav.melosys.eessi.service.buc;
+
+import java.util.NoSuchElementException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.SneakyThrows;
+import no.nav.melosys.eessi.models.BucType;
+import no.nav.melosys.eessi.models.SedType;
+import no.nav.melosys.eessi.models.buc.BUC;
+import no.nav.melosys.eessi.models.sed.SED;
+import no.nav.melosys.eessi.service.eux.EuxService;
+import no.nav.melosys.eessi.service.eux.OpprettBucOgSedResponse;
+import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KopierBucServiceTest {
+
+    @Mock
+    private EuxService euxService;
+    @Mock
+    private SaksrelasjonService saksrelasjonService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private KopierBucService kopierBucService;
+
+    private BUC buc;
+    private SED sedA001;
+
+    @BeforeEach
+    void setup() {
+        objectMapper.registerModule(new JavaTimeModule());
+        kopierBucService = new KopierBucService(euxService, saksrelasjonService);
+
+        buc = lesObjekt(BUC.class, "mock/buc.json");
+        sedA001 = lesObjekt(SED.class, "mock/sedA001.json");
+    }
+
+    @Test
+    void kopierBUC_laBuc01A001Finnes_oppretterNyBucMedYtterligereInfoOgOppdatererSaksrelasjon() {
+        final var rinaSaksnummer = "12423";
+        final var forventetNyRinasaksnummer = "222223";
+
+        buc.getDocuments()
+                .stream()
+                .filter(d -> SedType.A001.name().equals(d.getType()))
+                .findFirst()
+                .ifPresent(d -> d.setStatus("SENT"));
+
+        when(euxService.hentBuc(rinaSaksnummer)).thenReturn(buc);
+        when(euxService.hentSed(eq(rinaSaksnummer), anyString())).thenReturn(sedA001);
+        when(euxService.opprettBucOgSed(eq(BucType.LA_BUC_01), anyCollection(), eq(sedA001), anyCollection()))
+                .thenReturn(new OpprettBucOgSedResponse(forventetNyRinasaksnummer, ""));
+
+        assertThat(kopierBucService.kopierBUC(rinaSaksnummer)).isEqualTo(forventetNyRinasaksnummer);
+        assertThat(sedA001.getNav().getYtterligereinformasjon()).isNotEmpty()
+                .contains(SedType.A001.name(), buc.getInternationalId())
+                .hasSizeLessThan(500); //Maks-lengde i RINA
+    }
+
+    @Test
+    void kopierBUC_laBuc01A001FinnesIkke_kasterFeil() {
+        final var rinaSaksnummer = "12423";
+        when(euxService.hentBuc(rinaSaksnummer)).thenReturn(buc);
+        assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(() -> kopierBucService.kopierBUC(rinaSaksnummer))
+                .withMessageContaining("Finner ikke første");
+    }
+
+    @SneakyThrows
+    private <T> T lesObjekt(Class<T> clazz, String fil) {
+        return objectMapper.readValue(getClass().getClassLoader().getResource(fil), clazz);
+    }
+}


### PR DESCRIPTION
Grunnet skadede BUCer ved at vi automatisk har forsøkte å sende SED for kort tid etter opprettelse, må vi sende disse SEDer på nytt, i nye BUCer. 

Lager et enkelt endepunkt som tar i mot en liste av rina-saker (saksnummer), og kopierer over første SED i en BUC til en ny BUC.