### PR TITLE
Erstatter all bruk av Junit 4 med Junit5

### DIFF
--- a/melosys-eessi-app/pom.xml
+++ b/melosys-eessi-app/pom.xml
@@ -178,27 +178,6 @@
             <version>${random-benas.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- For å støtte både Junit 4 og Junit 5 -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -101,7 +101,7 @@ public class EuxService {
     }
 
     public boolean sedErEndring(String sedId, String rinaSaksnummer) {
-        BUC buc = euxConsumer.hentBuC(rinaSaksnummer);
+        var buc = euxConsumer.hentBuC(rinaSaksnummer);
 
         return buc.getDocuments().stream()
                 .filter(document -> document.getId().equals(sedId)).findFirst()
@@ -130,7 +130,7 @@ public class EuxService {
 
     public String hentRinaUrl(String rinaCaseId) {
         if (!StringUtils.hasText(rinaCaseId)) {
-            throw new IllegalArgumentException("Trenger RinaSaksnummer for å opprette url til rina");
+            throw new IllegalArgumentException("Trenger rina-saksnummer for å opprette url til rina");
         }
         return rinaHostUrl + RINA_URL_TEMPLATE + rinaCaseId;
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/controller/dto/SedStatusTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/controller/dto/SedStatusTest.java
@@ -1,12 +1,14 @@
 package no.nav.melosys.eessi.controller.dto;
 
-import org.junit.Test;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
-public class SedStatusTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class SedStatusTest {
 
     @Test
-    public void fraNorskStatus_medGyldigeStatuser_forventRettStatus() {
+    void fraNorskStatus_medGyldigeStatuser_forventRettStatus() {
         String tom = "tom";
         String utkast = "utkast";
 
@@ -14,14 +16,15 @@ public class SedStatusTest {
         assertThat(SedStatus.fraNorskStatus(utkast)).isEqualTo(SedStatus.UTKAST);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void fraNorskStatus_medUgyldigStatus_forventException() {
+    @Test
+    void fraNorskStatus_medUgyldigStatus_forventException() {
         String ugyldigStatus = "abc123";
-        SedStatus.fraNorskStatus(ugyldigStatus);
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> SedStatus.fraNorskStatus(ugyldigStatus));
     }
 
     @Test
-    public void fraNorskStatus_medTomStatus_forventNull() {
+    void fraNorskStatus_medTomStatus_forventNull() {
         String tomStatus = "";
 
         assertThat(SedStatus.fraNorskStatus(tomStatus)).isNull();
@@ -29,7 +32,7 @@ public class SedStatusTest {
     }
 
     @Test
-    public void fraEngelskStatus_medGyldigeStatuser_forventRettStatus() {
+    void fraEngelskStatus_medGyldigeStatuser_forventRettStatus() {
         String empty = "empty";
         String statusNew = "new";
 
@@ -38,14 +41,14 @@ public class SedStatusTest {
     }
 
     @Test
-    public void fraEngelskStatus_medUgyldigStatus_forventNull() {
+    void fraEngelskStatus_medUgyldigStatus_forventNull() {
         String ugyldigStatus = "abc123";
 
         assertThat(SedStatus.fraEngelskStatus(ugyldigStatus)).isNull();
     }
 
     @Test
-    public void fraEngelskStatus_medTomStatus_forventNull() {
+    void fraEngelskStatus_medTomStatus_forventNull() {
         String tomStatus = "";
 
         assertThat(SedStatus.fraEngelskStatus(tomStatus)).isNull();
@@ -53,7 +56,7 @@ public class SedStatusTest {
     }
 
     @Test
-    public void erGyldigStatus() {
+    void erGyldigStatus() {
         assertThat(SedStatus.erGyldigEngelskStatus("empty")).isFalse();
         assertThat(SedStatus.erGyldigEngelskStatus("sent")).isTrue();
         assertThat(SedStatus.erGyldigEngelskStatus("new")).isFalse();

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/dokkat/DokumenttypeIdConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/dokkat/DokumenttypeIdConsumerTest.java
@@ -2,40 +2,40 @@ package no.nav.melosys.eessi.integration.dokkat;
 
 import no.nav.melosys.eessi.integration.dokkat.dto.DokumenttypeIdDto;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@RunWith(MockitoJUnitRunner.class)
-public class DokumenttypeIdConsumerTest {
+@ExtendWith(MockitoExtension.class)
+class DokumenttypeIdConsumerTest {
 
 
     @Spy
     private RestTemplate restTemplate;
 
-    @InjectMocks
     private DokumenttypeIdConsumer dokumenttypeIdConsumer;
 
     private MockRestServiceServer server;
 
-    @Before
+    @BeforeEach
     public void setup() {
+        dokumenttypeIdConsumer = new DokumenttypeIdConsumer(restTemplate);
         server = MockRestServiceServer.createServer(restTemplate);
     }
 
     @Test
-    public void hentDokumenttypeId_expectValidJson() {
+    void hentDokumenttypeId_expectValidJson() {
 
         String responseJson = "{\"dokumenttypeId\":\"123\"}";
         server.expect(requestTo("/sed/type"))
@@ -46,10 +46,12 @@ public class DokumenttypeIdConsumerTest {
         assertThat(dokumenttypeIdDto.getDokumenttypeId()).isEqualTo("123");
     }
 
-    @Test(expected = IntegrationException.class)
-    public void hentDokumenttypeId_expectException() {
+    @Test
+    void hentDokumenttypeId_expectException() {
         server.expect(requestTo("/sed/type"))
                 .andRespond(withServerError());
-        dokumenttypeIdConsumer.hentDokumenttypeId("sed", "type");
+        assertThatExceptionOfType(IntegrationException.class)
+                .isThrownBy(() -> dokumenttypeIdConsumer.hentDokumenttypeId("sed", "type"))
+                .withMessageContaining("Feil ved integrasjon mot dokkat");
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/dokkat/DokumenttypeInfoConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/dokkat/DokumenttypeInfoConsumerTest.java
@@ -5,27 +5,27 @@ import io.github.benas.randombeans.api.EnhancedRandom;
 import no.nav.melosys.eessi.EnhancedRandomCreator;
 import no.nav.melosys.eessi.integration.dokkat.dto.DokumentTypeInfoDto;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@RunWith(MockitoJUnitRunner.class)
-public class DokumenttypeInfoConsumerTest {
+@ExtendWith(MockitoExtension.class)
+class DokumenttypeInfoConsumerTest {
 
     @Spy
     private RestTemplate restTemplate;
 
-    @InjectMocks
     private DokumenttypeInfoConsumer dokumenttypeInfoConsumer;
 
     private MockRestServiceServer server;
@@ -34,14 +34,15 @@ public class DokumenttypeInfoConsumerTest {
 
     private final String dokumentyypeId = "123";
 
-    @Before
+    @BeforeEach
     public void setup() {
+        dokumenttypeInfoConsumer = new DokumenttypeInfoConsumer(restTemplate);
         server = MockRestServiceServer.createServer(restTemplate);
         enhancedRandom = EnhancedRandomCreator.defaultEnhancedRandom();
     }
 
     @Test
-    public void hentDokumenttypeInfo_expectValidJson() throws Exception {
+    void hentDokumenttypeInfo_expectValidJson() throws Exception {
         DokumentTypeInfoDto dokumentTypeInfoDto = enhancedRandom.nextObject(DokumentTypeInfoDto.class);
         String responseJson = new ObjectMapper().writeValueAsString(dokumentTypeInfoDto);
 
@@ -56,10 +57,12 @@ public class DokumenttypeInfoConsumerTest {
         assertThat(responseObject.getDokumentKategori()).isEqualTo(dokumentTypeInfoDto.getDokumentKategori());
     }
 
-    @Test(expected = IntegrationException.class)
-    public void hentDokumenttypeId_expectException() throws Exception {
+    @Test
+    void hentDokumenttypeId_expectException() {
         server.expect(requestTo("/" + dokumentyypeId))
                 .andRespond(withServerError());
-        dokumenttypeInfoConsumer.hentDokumenttypeInfo(dokumentyypeId);
+        assertThatExceptionOfType(IntegrationException.class)
+                .isThrownBy(() -> dokumenttypeInfoConsumer.hentDokumenttypeInfo(dokumentyypeId))
+                .withMessageContaining("Feil ved integrasjon mot dokkat");
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/case_store/CaseStoreConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/case_store/CaseStoreConsumerTest.java
@@ -1,23 +1,25 @@
 package no.nav.melosys.eessi.integration.eux.case_store;
 
 import java.util.Collections;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-public class CaseStoreConsumerTest {
+class CaseStoreConsumerTest {
 
     private CaseStoreConsumer caseStoreConsumer;
 
     private MockRestServiceServer server;
     private String response;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         RestTemplate restTemplate = new RestTemplate();
         server = MockRestServiceServer.createServer(restTemplate);
@@ -26,7 +28,7 @@ public class CaseStoreConsumerTest {
     }
 
     @Test
-    public void finnVedRinaSaksnummer() throws Exception {
+    void finnVedRinaSaksnummer() {
         String rinaSaksnummer = "12312432";
         server.expect(requestTo("/cases?rinaId=" + rinaSaksnummer))
                 .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
@@ -34,7 +36,7 @@ public class CaseStoreConsumerTest {
     }
 
     @Test
-    public void finnVedJournalpostID() throws Exception {
+    void finnVedJournalpostID() {
         String journalpostID = "12312432";
         server.expect(requestTo("/cases?caseFileId=" + journalpostID))
                 .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerProducerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerProducerTest.java
@@ -5,18 +5,18 @@ import java.util.Optional;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import no.nav.melosys.eessi.security.SystemContextClientRequestInterceptor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class EuxConsumerProducerTest {
+class EuxConsumerProducerTest {
 
     @Test
-    public void opprettResttemplate_verifiserModifisertObjectMapper() {
+    void opprettResttemplate_verifiserModifisertObjectMapper() {
         EuxConsumerProducer euxConsumerProducer = new EuxConsumerProducer("uri");
         RestTemplate restTemplate = euxConsumerProducer.euxRestTemplate(new RestTemplateBuilder(r -> {}), mock(
                 SystemContextClientRequestInterceptor.class));
@@ -27,13 +27,13 @@ public class EuxConsumerProducerTest {
                 .map(MappingJackson2HttpMessageConverter.class::cast)
                 .findFirst();
 
-        assertThat(converter.isPresent()).isTrue();
+        assertThat(converter).isPresent();
 
         //Sjekker at objectMapper ikke feiler ved manglende typeId (eks SED.medlemskap)
         ObjectMapper objectMapper = converter.get().getObjectMapper();
-        assertThat(
-                objectMapper.getDeserializationConfig()
-                        .hasDeserializationFeatures(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY.getMask())
+        assertThat(objectMapper
+                .getDeserializationConfig()
+                .hasDeserializationFeatures(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY.getMask())
         ).isFalse();
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerTest.java
@@ -20,8 +20,8 @@ import no.nav.melosys.eessi.models.sed.nav.Nav;
 import no.nav.melosys.eessi.security.SystemContextClientRequestInterceptor;
 import no.nav.melosys.eessi.service.sts.RestStsService;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -32,14 +32,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-public class EuxConsumerTest {
+class EuxConsumerTest {
 
     private EuxConsumer euxConsumer;
 
@@ -47,8 +46,8 @@ public class EuxConsumerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         EuxConsumerProducer consumerConfig = new EuxConsumerProducer(null);
         SystemContextClientRequestInterceptor interceptor = new SystemContextClientRequestInterceptor(mock(RestStsService.class));
 
@@ -58,7 +57,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentBuC_returnerObjekt() throws Exception {
+    void hentBuC_returnerObjekt() throws Exception {
 
         URL jsonUrl = getClass().getClassLoader().getResource("mock/buc.json");
         assertThat(jsonUrl).isNotNull();
@@ -85,7 +84,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void opprettBuC_returnererId() {
+    void opprettBuC_returnererId() {
         String id = "1234";
         String buc = "LA_BUC_04";
         server.expect(requestTo("/buc?BuCType=" + buc))
@@ -96,7 +95,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void slettBuC_ingenRetur() {
+    void slettBuC_ingenRetur() {
         String id = "1234";
         server.expect(requestTo("/buc/" + id))
                 .andExpect(method(HttpMethod.DELETE))
@@ -106,7 +105,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void settMottaker_ingenRetur() {
+    void settMottaker_ingenRetur() {
         String rinaSaksnummer = "1111";
         String sverige = "SE:1234";
         String danmark = "DK:4321";
@@ -118,7 +117,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void settMottaker_respons404_kasterNotFoundException() {
+    void settMottaker_respons404_kasterNotFoundException() {
         String rinaSaksnummer = "1111";
         String sverige = "SE:1234";
         String danmark = "DK:4321";
@@ -132,7 +131,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentInstitusjoner_forventListe() throws Exception {
+    void hentInstitusjoner_forventListe() throws Exception {
         URL jsonUrl = getClass().getClassLoader().getResource("mock/institusjon_liste.json");
         assertThat(jsonUrl).isNotNull();
         String institusjonerString = IOUtils.toString(new InputStreamReader(new FileInputStream(jsonUrl.getFile())));
@@ -153,7 +152,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void opprettBucOgSedMedVedlegg_forventString() throws Exception {
+    void opprettBucOgSedMedVedlegg_forventString() throws Exception {
         String buc = "buc", mottaker = "NAV", filtype = "virus.exe", vedlegg = "vedlegg";
         SED sed = new SED();
 
@@ -170,7 +169,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void finnRinaSaker_forventJson() throws Exception {
+    void finnRinaSaker_forventJson() throws Exception {
         URL jsonUrl = getClass().getClassLoader().getResource("mock/bucinfo.json");
         assertThat(jsonUrl).isNotNull();
         String forventetRetur = IOUtils.toString(new InputStreamReader(new FileInputStream(jsonUrl.getFile())));
@@ -193,12 +192,12 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedA001_forventSed() throws Exception {
+    void hentSedA001_forventSed() throws Exception {
         String id = "123";
         String dokumentId = "312";
 
         URL jsonUrl = getClass().getClassLoader().getResource("mock/sedA001.json");
-        assertNotNull(jsonUrl);
+        assertThat(jsonUrl).isNotNull();
         String sed = IOUtils.toString(new InputStreamReader(new FileInputStream(jsonUrl.getFile())));
 
         server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId))
@@ -217,7 +216,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedA003_forventSed() throws Exception {
+    void hentSedA003_forventSed() throws Exception {
         String id = "123";
         String dokumentId = "312";
 
@@ -240,7 +239,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedA008_forventSed() throws Exception {
+    void hentSedA008_forventSed() throws Exception {
         String id = "123";
         String dokumentId = "312";
 
@@ -263,12 +262,12 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedA009_forventSed() throws Exception {
+    void hentSedA009_forventSed() throws Exception {
         String id = "123";
         String dokumentId = "312";
 
         URL jsonUrl = getClass().getClassLoader().getResource("mock/sedA009.json");
-        assertNotNull(jsonUrl);
+        assertThat(jsonUrl).isNotNull();
         String sed = IOUtils.toString(new InputStreamReader(new FileInputStream(jsonUrl.getFile())));
 
         server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId))
@@ -283,12 +282,12 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedA010_forventSed() throws Exception {
+    void hentSedA010_forventSed() throws Exception {
         String id = "123";
         String dokumentId = "312";
 
         URL jsonUrl = getClass().getClassLoader().getResource("mock/sedA010.json");
-        assertNotNull(jsonUrl);
+        assertThat(jsonUrl).isNotNull();
         String sed = IOUtils.toString(new InputStreamReader(new FileInputStream(jsonUrl.getFile())));
 
         server.expect(requestTo("/buc/" + id + "/sed/" + dokumentId))
@@ -303,7 +302,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedX001_forventSed() throws Exception {
+    void hentSedX001_forventSed() throws Exception {
         String id = "123";
         String dokumentId = "312";
 
@@ -322,7 +321,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedH001MedArbeidsgiver_forventSed() throws Exception {
+    void hentSedH001MedArbeidsgiver_forventSed() throws Exception {
         String id = "123";
         String dokumentId = "312";
 
@@ -342,7 +341,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void hentSedPdf_forventPdf() {
+    void hentSedPdf_forventPdf() {
         String id = "123", dokumentId = "123321";
 
         byte[] forventetRetur = "teststring".getBytes();
@@ -355,7 +354,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void genererPdfFraSed_forventPdf() {
+    void genererPdfFraSed_forventPdf() {
         SED sed = new SED();
         byte[] forventetRetur = "teststring".getBytes();
 
@@ -367,7 +366,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void opprettSed_forventId() {
+    void opprettSed_forventId() {
         String id = "123";
         SED sed = new SED();
 
@@ -381,7 +380,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void oppdaterSed_ingenRetur() {
+    void oppdaterSed_ingenRetur() {
         String id = "123";
         String dokumentId = "1111";
         SED sed = new SED();
@@ -393,7 +392,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void sendSed_ingenRetur() {
+    void sendSed_ingenRetur() {
         String id = "123";
         String dokumentId = "22";
 
@@ -404,7 +403,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void leggTilVedlegg_forventId() {
+    void leggTilVedlegg_forventId() {
         final String id = "123";
         final String dokumentId = "123321";
         final String filtype = "virus.exe";
@@ -421,7 +420,7 @@ public class EuxConsumerTest {
     }
 
     @Test
-    public void setSakSensitiv_ingenResponseEllerException() {
+    void setSakSensitiv_ingenResponseEllerException() {
 
         String id ="123";
         server.expect(requestTo("/buc/" + id + "/sensitivsak"))

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/journalpostapi/JournalpostFiltypeTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/journalpostapi/JournalpostFiltypeTest.java
@@ -3,28 +3,28 @@ package no.nav.melosys.eessi.integration.journalpostapi;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JournalpostFiltypeTest {
+class JournalpostFiltypeTest {
 
     @Test
-    public void filnavn_pdfEndelse_forventPDF() {
+    void filnavn_pdfEndelse_forventPDF() {
         String filnavn = "titteipådeg.pdf";
         String mimeType = "123IkkeGyldigMimeType";
         assertFiltype(filnavn, mimeType, JournalpostFiltype.PDF);
     }
 
     @Test
-    public void filnavn_jpsEndelse_forventJPEG() {
+    void filnavn_jpsEndelse_forventJPEG() {
         String filnavn = "titteipådeg.jpg";
         String mimeType = "123IkkeGyldigMimeType";
         assertFiltype(filnavn, mimeType, JournalpostFiltype.JPEG);
     }
 
     @Test
-    public void filnavn_filnavnErTomt_forventOptionalEmpty() {
+    void filnavn_filnavnErTomt_forventOptionalEmpty() {
         String filnavn = "abc_234gf_T43T_re4";
         String mimeType = null;
         Optional<JournalpostFiltype> journalpostFiltype = JournalpostFiltype.fraMimeOgFilnavn(mimeType, filnavn);
@@ -32,7 +32,7 @@ public class JournalpostFiltypeTest {
     }
 
     @Test
-    public void filnavn_filnavnErNullMimetypePdf_forventPDFA() {
+    void filnavn_filnavnErNullMimetypePdf_forventPDFA() {
         String filnavn = "abc_234gf_T43T_re4";
         String mimeType = "application/pdf";
         Optional<JournalpostFiltype> journalpostFiltype = JournalpostFiltype.fraMimeOgFilnavn(mimeType, filnavn);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/sak/SakConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/sak/SakConsumerTest.java
@@ -1,19 +1,20 @@
 package no.nav.melosys.eessi.integration.sak;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SakConsumerTest {
+@ExtendWith(MockitoExtension.class)
+class SakConsumerTest {
 
     private SakConsumer sakConsumer;
 
@@ -22,14 +23,14 @@ public class SakConsumerTest {
 
     private MockRestServiceServer server;
 
-    @Before
+    @BeforeEach
     public void setup() {
         sakConsumer = new SakConsumer(restTemplate);
         server = MockRestServiceServer.createServer(restTemplate);
     }
 
     @Test
-    public void getSak_expectSak() throws Exception {
+    void getSak_expectSak() {
         String responseJson = "{\"id\":\"11\",\"tema\":\"MED\",\"applikasjon\":\"melsoys\","
                 + "\"aktoerId\":\"123\",\"orgnr\":\"12312312\",\"fagsakNr\":\"fag123\","
                 + "\"opprettetAv\":\"srvmelosys\",\"opprettetTidspunkt\":\"2019-02-11T08:33:38.964Z\"}";

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/jobs/SedMottattJobbTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/jobs/SedMottattJobbTest.java
@@ -7,17 +7,17 @@ import no.nav.melosys.eessi.models.SedMottatt;
 import no.nav.melosys.eessi.models.exception.IntegrationException;
 import no.nav.melosys.eessi.service.behandling.BehandleSedMottattService;
 import no.nav.melosys.eessi.service.sed.SedMottattService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SedMottattJobbTest {
+@ExtendWith(MockitoExtension.class)
+class SedMottattJobbTest {
 
     @Mock
     private SedMottattService sedMottattService;
@@ -26,13 +26,13 @@ public class SedMottattJobbTest {
 
     private SedMottattJobb sedMottattJobb;
 
-    @Before
+    @BeforeEach
     public void setup() {
         sedMottattJobb = new SedMottattJobb(sedMottattService, behandleSedMottattService);
     }
 
     @Test
-    public void sedMottattJobb_4HendelserSkalKjøres_2FeilerOgLagres() throws Exception {
+    void sedMottattJobb_4HendelserSkalKjøres_2FeilerOgLagres() {
         SedMottatt feil1 = SedMottatt.av(new SedHendelse());
         feil1.setFeiledeForsok(2);
         SedMottatt feil2 = SedMottatt.av(new SedHendelse());
@@ -43,8 +43,8 @@ public class SedMottattJobbTest {
         SedMottatt sedMottatt2 = SedMottatt.av(new SedHendelse());
         sedMottatt2.setFeiledeForsok(1);
 
-        doThrow(new IntegrationException("feil1")).when(behandleSedMottattService).behandleSed(eq(feil1));
-        doThrow(new IntegrationException("feil2")).when(behandleSedMottattService).behandleSed(eq(feil2));
+        doThrow(new IntegrationException("feil1")).when(behandleSedMottattService).behandleSed(feil1);
+        doThrow(new IntegrationException("feil2")).when(behandleSedMottattService).behandleSed(feil2);
 
         when(sedMottattService.hentAlleUbehandlet()).thenReturn(Arrays.asList(feil1, feil2, sedMottatt1, sedMottatt2));
 
@@ -54,7 +54,7 @@ public class SedMottattJobbTest {
         assertThat(feil1.isFeilet()).isTrue();
         assertThat(feil2.getFeiledeForsok()).isEqualTo(2);
         assertThat(feil2.isFeilet()).isFalse();
-        assertThat(sedMottatt1.getFeiledeForsok()).isEqualTo(0);
+        assertThat(sedMottatt1.getFeiledeForsok()).isZero();
         assertThat(sedMottatt2.getFeiledeForsok()).isEqualTo(1);
 
         verify(sedMottattService, times(4)).lagre(any());

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/buc/BUCTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/buc/BUCTest.java
@@ -5,14 +5,14 @@ import java.time.ZonedDateTime;
 
 import com.google.common.collect.Lists;
 import no.nav.melosys.eessi.controller.dto.SedStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BUCTest {
+class BUCTest {
 
     @Test
-    public void hentSistOppdaterteDocument() {
+    void hentSistOppdaterteDocument() {
         BUC buc = new BUC();
 
         Document document1 = new Document();

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/buc/SedVersjonSjekkerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/buc/SedVersjonSjekkerTest.java
@@ -3,17 +3,17 @@ package no.nav.melosys.eessi.models.buc;
 
 import no.nav.melosys.eessi.models.sed.Konstanter;
 import no.nav.melosys.eessi.models.sed.SED;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SedVersjonSjekkerTest {
+class SedVersjonSjekkerTest {
 
-    private BUC buc = new BUC();
-    private SED sed = new SED();
+    private final BUC buc = new BUC();
+    private final SED sed = new SED();
 
     @Test
-    public void verifiserSedVersjonErBucVersjon_erLikVersjon_oppdateresIkke() {
+    void verifiserSedVersjonErBucVersjon_erLikVersjon_oppdateresIkke() {
 
         buc.setBucVersjon("v4.1");
         sed.setSedGVer("4");
@@ -25,7 +25,7 @@ public class SedVersjonSjekkerTest {
     }
 
     @Test
-    public void verifiserSedVersjonErBucVersjon_erForskjelligVersjon_oppdateres() {
+    void verifiserSedVersjonErBucVersjon_erForskjelligVersjon_oppdateres() {
 
         buc.setBucVersjon("v5.4");
         sed.setSedGVer("4");
@@ -37,7 +37,7 @@ public class SedVersjonSjekkerTest {
     }
 
     @Test
-    public void hentBucVersjon_riktigFormat_fungerer() {
+    void hentBucVersjon_riktigFormat_fungerer() {
         buc.setBucVersjon("v4.0");
 
         assertThat(SedVersjonSjekker.parseGVer(buc)).isEqualTo("4");
@@ -45,7 +45,7 @@ public class SedVersjonSjekkerTest {
     }
 
     @Test
-    public void hentBucVersjon_uventetFormat_fårDefault() {
+    void hentBucVersjon_uventetFormat_fårDefault() {
         buc.setBucVersjon("v21");
 
         assertThat(SedVersjonSjekker.parseGVer(buc)).isEqualTo(Konstanter.DEFAULT_SED_G_VER);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/sed/medlemskap/impl/SvarAnmodningUnntakBeslutningTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/models/sed/medlemskap/impl/SvarAnmodningUnntakBeslutningTest.java
@@ -1,12 +1,13 @@
 package no.nav.melosys.eessi.models.sed.medlemskap.impl;
 
-import org.junit.Test;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
-public class SvarAnmodningUnntakBeslutningTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SvarAnmodningUnntakBeslutningTest {
 
     @Test
-    public void beslutningAvslag() {
+    void beslutningAvslag() {
         SvarAnmodningUnntakBeslutning beslutning = SvarAnmodningUnntakBeslutning.fraRinaKode("ikke_godkjent");
 
         assertThat(beslutning).isEqualTo(SvarAnmodningUnntakBeslutning.AVSLAG);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/BasicAuthClientRequestInterceptorTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/BasicAuthClientRequestInterceptorTest.java
@@ -3,24 +3,26 @@ package no.nav.melosys.eessi.security;
 
 import java.util.Base64;
 import java.util.List;
+
 import no.nav.melosys.eessi.config.AppCredentials;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.mock.http.client.MockClientHttpRequest;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class BasicAuthClientRequestInterceptorTest {
+class BasicAuthClientRequestInterceptorTest {
 
     private BasicAuthClientRequestInterceptor interceptor;
     private AppCredentials appCredentials;
 
-    @Before
+    @BeforeEach
     public void setup() {
         appCredentials = new AppCredentials();
         appCredentials.setUsername("usr");
@@ -30,7 +32,7 @@ public class BasicAuthClientRequestInterceptorTest {
     }
 
     @Test
-    public void intercept_medGyldigAuth_verifiserToken() throws Exception {
+    void intercept_medGyldigAuth_verifiserToken() throws Exception {
         String expectedToken = "Basic " + Base64.getEncoder().encodeToString(
                 (appCredentials.getUsername() + ":" + appCredentials.getPassword()).getBytes()
         );

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/SystemContextClientRequestInterceptorTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/SystemContextClientRequestInterceptorTest.java
@@ -1,12 +1,11 @@
 package no.nav.melosys.eessi.security;
 
 import no.nav.melosys.eessi.service.sts.RestStsService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
@@ -17,12 +16,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SystemContextClientRequestInterceptorTest {
+@ExtendWith(MockitoExtension.class)
+class SystemContextClientRequestInterceptorTest {
 
     @Mock
     private RestStsService restStsService;
-    @InjectMocks
+
     private SystemContextClientRequestInterceptor systemContextClientRequestInterceptor;
 
     @Mock
@@ -30,12 +29,14 @@ public class SystemContextClientRequestInterceptorTest {
 
     private final String oidcKey = "t43i56oh4yoi5";
 
-    @Before
+    @BeforeEach
     public void setup() {
+        systemContextClientRequestInterceptor = new SystemContextClientRequestInterceptor(restStsService);
         when(restStsService.collectToken()).thenReturn(oidcKey);
     }
+
     @Test
-    public void intercept() throws Exception {
+    void intercept() throws Exception {
         MockClientHttpRequest httpRequest = new MockClientHttpRequest();
         systemContextClientRequestInterceptor.intercept(httpRequest, new byte[0], httpRequestExecution);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/dokkat/DokkatServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/dokkat/DokkatServiceTest.java
@@ -4,19 +4,19 @@ import no.nav.melosys.eessi.integration.dokkat.DokumenttypeIdConsumer;
 import no.nav.melosys.eessi.integration.dokkat.DokumenttypeInfoConsumer;
 import no.nav.melosys.eessi.integration.dokkat.dto.DokumentTypeInfoDto;
 import no.nav.melosys.eessi.integration.dokkat.dto.DokumenttypeIdDto;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class DokkatServiceTest {
+@ExtendWith(MockitoExtension.class)
+class DokkatServiceTest {
 
     @Mock
     private DokumenttypeInfoConsumer dokumenttypeInfoConsumer;
@@ -24,14 +24,15 @@ public class DokkatServiceTest {
     @Mock
     private DokumenttypeIdConsumer dokumenttypeIdConsumer;
 
-    @InjectMocks
     private DokkatService dokkatService;
 
     private final String sedType = "A009";
     private final String dokumentTypeId = "sed-123";
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
+        dokkatService = new DokkatService(dokumenttypeIdConsumer, dokumenttypeInfoConsumer);
+
         DokumenttypeIdDto dokumenttypeIdTo = new DokumenttypeIdDto();
         dokumenttypeIdTo.setDokumenttypeId(dokumentTypeId);
         when(dokumenttypeIdConsumer.hentDokumenttypeId(eq(sedType), anyString())).thenReturn(dokumenttypeIdTo);
@@ -46,16 +47,15 @@ public class DokkatServiceTest {
                 .dokumenttypeId(dokumentTypeId)
                 .tema("tema")
                 .build();
-        when(dokumenttypeInfoConsumer.hentDokumenttypeInfo(eq(dokumentTypeId))).thenReturn(dokumentTypeInfoToV4);
+        when(dokumenttypeInfoConsumer.hentDokumenttypeInfo(dokumentTypeId)).thenReturn(dokumentTypeInfoToV4);
     }
 
     @Test
-    public void hentMetaDataFraDokkat_expectDokkatSedInfo() throws Exception {
+    void hentMetaDataFraDokkat_expectDokkatSedInfo() {
         DokkatSedInfo dokkatSedInfo = dokkatService.hentMetadataFraDokkat(sedType);
 
         assertThat(dokkatSedInfo).isNotNull();
         assertThat(dokkatSedInfo.getBehandlingstema()).isEqualTo("behandlingstema");
         assertThat(dokkatSedInfo.getDokumenttypeId()).isEqualTo(dokumentTypeId);
     }
-
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
@@ -2,34 +2,37 @@ package no.nav.melosys.eessi.service.helpers;
 
 import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
-public class LandkodeMapperTest {
+class LandkodeMapperTest {
 
     @Test
-    public void getIso2_expectIso2() throws NotFoundException {
+    void getIso2_expectIso2() throws NotFoundException {
         assertThat(LandkodeMapper.getLandkodeIso2("NOR")).isEqualTo("NO");
         assertThat(LandkodeMapper.getLandkodeIso2("SWE")).isEqualTo("SE");
         assertThat(LandkodeMapper.getLandkodeIso2("DNK")).isEqualTo("DK");
     }
 
     @Test
-    public void getIso2_withIso2_expectIso2() throws NotFoundException {
+    void getIso2_withIso2_expectIso2() throws NotFoundException {
         assertThat(LandkodeMapper.getLandkodeIso2("NO")).isEqualTo("NO");
         assertThat(LandkodeMapper.getLandkodeIso2("SE")).isEqualTo("SE");
         assertThat(LandkodeMapper.getLandkodeIso2("DK")).isEqualTo("DK");
     }
 
-    @Test(expected = NotFoundException.class)
-    public void getIso3_expectNotFoundException() throws NotFoundException {
-        LandkodeMapper.getLandkodeIso2("ABC");
+    @Test
+    void getIso3_expectNotFoundException() throws NotFoundException {
+        assertThatExceptionOfType(NotFoundException.class)
+                .isThrownBy(() -> LandkodeMapper.getLandkodeIso2("ABC"))
+                .withMessageContaining("ikke funnet");
     }
 
     @Test
-    public void getIso2_medIkkeISOStandardKoder_forventSammeKodeTilbake() throws NotFoundException {
+    void getIso2_medIkkeISOStandardKoder_forventSammeKodeTilbake() throws NotFoundException {
         assertThat(LandkodeMapper.getLandkodeIso2("???")).isEqualTo("???");
         assertThat(LandkodeMapper.getLandkodeIso2("XXX")).isEqualTo("XS");
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/JournalpostServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/JournalpostServiceTest.java
@@ -1,6 +1,7 @@
 package no.nav.melosys.eessi.service.joark;
 
 import java.util.Collections;
+
 import io.github.benas.randombeans.api.EnhancedRandom;
 import no.nav.melosys.eessi.EnhancedRandomCreator;
 import no.nav.melosys.eessi.integration.journalpostapi.JournalpostapiConsumer;
@@ -10,24 +11,24 @@ import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
 import no.nav.melosys.eessi.service.dokkat.DokkatSedInfo;
 import no.nav.melosys.eessi.service.dokkat.DokkatService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class JournalpostServiceTest {
+@ExtendWith(MockitoExtension.class)
+class JournalpostServiceTest {
 
     @Mock
     private DokkatService dokkatService;
     @Mock
     private JournalpostapiConsumer journalpostapiConsumer;
-    @InjectMocks
+
     private JournalpostService journalpostService;
 
     private EnhancedRandom random = EnhancedRandomCreator.defaultEnhancedRandom();
@@ -36,8 +37,10 @@ public class JournalpostServiceTest {
     private Sak sak;
     private DokkatSedInfo dokkatSedInfo;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
+        journalpostService = new JournalpostService(dokkatService, journalpostapiConsumer);
+
         sedHendelse = random.nextObject(SedHendelse.class);
         sak = random.nextObject(Sak.class);
         dokkatSedInfo = random.nextObject(DokkatSedInfo.class);
@@ -46,13 +49,13 @@ public class JournalpostServiceTest {
     }
 
     @Test
-    public void opprettInngaaendeJournalpost_verifiserEndeligJfr() throws Exception {
+    void opprettInngaaendeJournalpost_verifiserEndeligJfr() {
         journalpostService.opprettInngaaendeJournalpost(sedHendelse, sak, sedMedVedlegg(new byte[0]), "123321");
         verify(journalpostapiConsumer).opprettJournalpost(any(OpprettJournalpostRequest.class), eq(false));
     }
 
     @Test
-    public void opprettUtgaaendeJournalpost_verifiserEndeligJfr() throws Exception {
+    void opprettUtgaaendeJournalpost_verifiserEndeligJfr() {
         journalpostService.opprettUtgaaendeJournalpost(sedHendelse, sak, sedMedVedlegg(new byte[0]), "123321");
         verify(journalpostapiConsumer).opprettJournalpost(any(OpprettJournalpostRequest.class), eq(true));
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/OpprettInngaaendeJournalpostServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/OpprettInngaaendeJournalpostServiceTest.java
@@ -2,6 +2,7 @@ package no.nav.melosys.eessi.service.joark;
 
 import java.util.Collections;
 import java.util.Optional;
+
 import com.google.common.collect.Lists;
 import io.github.benas.randombeans.api.EnhancedRandom;
 import no.nav.melosys.eessi.EnhancedRandomCreator;
@@ -14,18 +15,19 @@ import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
 import no.nav.melosys.eessi.service.journalpostkobling.JournalpostSedKoblingService;
 import no.nav.melosys.eessi.service.sak.SakService;
 import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class OpprettInngaaendeJournalpostServiceTest {
+@ExtendWith(MockitoExtension.class)
+class OpprettInngaaendeJournalpostServiceTest {
 
     @Mock
     private JournalpostService journalpostService;
@@ -44,7 +46,7 @@ public class OpprettInngaaendeJournalpostServiceTest {
     private static final String JOURNALPOST_ID = "11223344";
     private static final String GSAK_SAKSNUMMER = "123";
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
 
         opprettInngaaendeJournalpostService = new OpprettInngaaendeJournalpostService(sakService, saksrelasjonService, journalpostService, journalpostSedKoblingService);
@@ -54,17 +56,18 @@ public class OpprettInngaaendeJournalpostServiceTest {
         OpprettJournalpostResponse response = new OpprettJournalpostResponse(JOURNALPOST_ID, Lists.newArrayList(
                 new OpprettJournalpostResponse.Dokument("123")), null, null);
         when(journalpostService.opprettInngaaendeJournalpost(any(), any(), any(), any())).thenReturn(response);
-
-        Sak sak = enhancedRandom.nextObject(Sak.class);
-        sak.setId(GSAK_SAKSNUMMER);
-        when(sakService.hentsak(anyLong())).thenReturn(sak);
-        FagsakRinasakKobling fagsakRinasakKobling = new FagsakRinasakKobling();
-        fagsakRinasakKobling.setGsakSaksnummer(123L);
-        when(saksrelasjonService.finnVedRinaSaksnummer(anyString())).thenReturn(Optional.of(fagsakRinasakKobling));
     }
 
     @Test
-    public void arkiverInngaaendeSedHentSakinformasjon_journalpostOpprettet_forventMottattJournalpostID() throws Exception {
+    void arkiverInngaaendeSedHentSakinformasjon_journalpostOpprettet_forventMottattJournalpostID() {
+        FagsakRinasakKobling fagsakRinasakKobling = new FagsakRinasakKobling();
+        fagsakRinasakKobling.setGsakSaksnummer(123L);
+        when(saksrelasjonService.finnVedRinaSaksnummer(anyString())).thenReturn(Optional.of(fagsakRinasakKobling));
+
+        var sak = enhancedRandom.nextObject(Sak.class);
+        sak.setId(GSAK_SAKSNUMMER);
+        when(sakService.hentsak(anyLong())).thenReturn(sak);
+
         SakInformasjon sakInformasjon = opprettInngaaendeJournalpostService.arkiverInngaaendeSedHentSakinformasjon(sedMottatt, sedMedVedlegg(new byte[0]), "123");
 
         assertThat(sakInformasjon).isNotNull();
@@ -73,13 +76,13 @@ public class OpprettInngaaendeJournalpostServiceTest {
 
         verify(journalpostService, times(1)).opprettInngaaendeJournalpost(any(), any(), any(), anyString());
         verify(saksrelasjonService, times(1)).finnVedRinaSaksnummer(any());
-        verify(journalpostSedKoblingService).lagre(eq(JOURNALPOST_ID), eq(sedMottatt.getRinaSakId()),
-                eq(sedMottatt.getRinaDokumentId()), eq(sedMottatt.getRinaDokumentVersjon()),
-                eq(sedMottatt.getBucType()), eq(sedMottatt.getSedType()));
+        verify(journalpostSedKoblingService).lagre(JOURNALPOST_ID, sedMottatt.getRinaSakId(),
+                sedMottatt.getRinaDokumentId(), sedMottatt.getRinaDokumentVersjon(),
+                sedMottatt.getBucType(), sedMottatt.getSedType());
     }
 
     @Test
-    public void arkiverInngaaendeSedUtenBruker_journalpostOpprettet_forventReturnerJournalpostID() throws Exception {
+    void arkiverInngaaendeSedUtenBruker_journalpostOpprettet_forventReturnerJournalpostID() {
 
         String journalpostID = opprettInngaaendeJournalpostService.arkiverInngaaendeSedUtenBruker(sedMottatt, sedMedVedlegg(new byte[0]), "123321");
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostServiceTest.java
@@ -10,17 +10,15 @@ import no.nav.melosys.eessi.integration.PersonFasade;
 import no.nav.melosys.eessi.integration.journalpostapi.OpprettJournalpostResponse;
 import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
-import no.nav.melosys.eessi.models.exception.IntegrationException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
 import no.nav.melosys.eessi.service.eux.EuxService;
 import no.nav.melosys.eessi.service.oppgave.OppgaveService;
 import no.nav.melosys.eessi.service.sak.SakService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,8 +26,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class OpprettUtgaaendeJournalpostServiceTest {
+@ExtendWith(MockitoExtension.class)
+class OpprettUtgaaendeJournalpostServiceTest {
 
     private static final String JOURNALPOST_ID = "123";
 
@@ -49,17 +47,12 @@ public class OpprettUtgaaendeJournalpostServiceTest {
     private SedHendelse sedSendt;
     private final EnhancedRandom enhancedRandom = EnhancedRandomCreator.defaultEnhancedRandom();
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         opprettUtgaaendeJournalpostService = new OpprettUtgaaendeJournalpostService(
                 sakService, journalpostService, euxService, personFasade, oppgaveService);
 
-        OpprettJournalpostResponse response = new OpprettJournalpostResponse(JOURNALPOST_ID, new ArrayList<>(), "ENDELIG", null);
-        when(journalpostService.opprettUtgaaendeJournalpost(any(SedHendelse.class), any(), any(), any())).thenReturn(response);
         when(euxService.hentSedMedVedlegg(anyString(), anyString())).thenReturn(sedMedVedlegg(new byte[0]));
-        when(euxService.hentRinaUrl(anyString())).thenReturn("https://test.local");
-        when(personFasade.hentNorskIdent(anyString())).thenReturn("54321");
-        when(personFasade.hentAktoerId(anyString())).thenReturn("12345");
 
         Sak sak = enhancedRandom.nextObject(Sak.class);
         when(sakService.finnSakForRinaSaksnummer(anyString())).thenReturn(Optional.of(sak));
@@ -68,15 +61,22 @@ public class OpprettUtgaaendeJournalpostServiceTest {
     }
 
     @Test
-    public void arkiverUtgaaendeSed_forventId() {
+    void arkiverUtgaaendeSed_forventId() {
+        OpprettJournalpostResponse response = new OpprettJournalpostResponse(JOURNALPOST_ID, new ArrayList<>(), "ENDELIG", null);
+        when(journalpostService.opprettUtgaaendeJournalpost(any(SedHendelse.class), any(), any(), any())).thenReturn(response);
+        when(personFasade.hentNorskIdent(anyString())).thenReturn("54321");
+
         String result = opprettUtgaaendeJournalpostService.arkiverUtgaaendeSed(sedSendt);
         assertThat(result).isEqualTo(JOURNALPOST_ID);
     }
 
     @Test
-    public void arkiverUtgaaendeSed_ikkeEndelig_forventOpprettJfrOppgave() throws NotFoundException, IntegrationException {
+    void arkiverUtgaaendeSed_ikkeEndelig_forventOpprettJfrOppgave() {
         OpprettJournalpostResponse response = new OpprettJournalpostResponse(JOURNALPOST_ID, new ArrayList<>(), "MIDLERTIDIG", null);
         when(journalpostService.opprettUtgaaendeJournalpost(any(SedHendelse.class), any(), any(), any())).thenReturn(response);
+        when(euxService.hentRinaUrl(anyString())).thenReturn("https://test.local");
+        when(personFasade.hentAktoerId(anyString())).thenReturn("12345");
+        when(personFasade.hentNorskIdent(anyString())).thenReturn("54321");
 
         String result = opprettUtgaaendeJournalpostService.arkiverUtgaaendeSed(sedSendt);
 
@@ -88,8 +88,12 @@ public class OpprettUtgaaendeJournalpostServiceTest {
     }
 
     @Test
-    public void arkiverUtgaaendeSed_ingenSak_forventOpprettJfrOppgave() {
+    void arkiverUtgaaendeSed_ingenSak_forventOpprettJfrOppgave() {
+        OpprettJournalpostResponse response = new OpprettJournalpostResponse(JOURNALPOST_ID, new ArrayList<>(), "ENDELIG", null);
+        when(journalpostService.opprettUtgaaendeJournalpost(any(SedHendelse.class), any(), any(), any())).thenReturn(response);
+        when(euxService.hentRinaUrl(anyString())).thenReturn("https://test.local");
         when(sakService.finnSakForRinaSaksnummer(anyString())).thenReturn(Optional.empty());
+        when(personFasade.hentAktoerId(anyString())).thenReturn("12345");
 
         String journalpostId = opprettUtgaaendeJournalpostService.arkiverUtgaaendeSed(sedSendt);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingServiceTest.java
@@ -21,18 +21,18 @@ import no.nav.melosys.eessi.repository.JournalpostSedKoblingRepository;
 import no.nav.melosys.eessi.service.eux.EuxService;
 import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
 import no.nav.melosys.eessi.service.sed.mapper.fra_sed.melosys_eessi_melding.MelosysEessiMeldingMapperFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class JournalpostSedKoblingServiceTest {
+@ExtendWith(MockitoExtension.class)
+class JournalpostSedKoblingServiceTest {
     @Mock
     private JournalpostSedKoblingRepository journalpostSedKoblingRepository;
     @Mock
@@ -54,7 +54,7 @@ public class JournalpostSedKoblingServiceTest {
     private Organisation organisation;
     private JournalpostSedKobling journalpostSedKobling;
 
-    @Before
+    @BeforeEach
     public void setup() {
         journalpostSedKoblingService = new JournalpostSedKoblingService(
                 journalpostSedKoblingRepository, caseStoreConsumer, euxService, saksrelasjonService,
@@ -77,7 +77,7 @@ public class JournalpostSedKoblingServiceTest {
     }
 
     @Test
-    public void finnVedJournalpostIDOpprettMelosysEessiMelding_sakEksistererIDB_forventMelosysEessiMelding() throws Exception {
+    void finnVedJournalpostIDOpprettMelosysEessiMelding_sakEksistererIDB_forventMelosysEessiMelding() {
         when(journalpostSedKoblingRepository.findByJournalpostID(anyString()))
                 .thenReturn(Optional.of(journalpostSedKobling));
         when(euxService.hentBuc(anyString())).thenReturn(buc);
@@ -92,7 +92,7 @@ public class JournalpostSedKoblingServiceTest {
     }
 
     @Test
-    public void finnVedJournalpostIDOpprettMelosysEessiMelding_sakEksistererIEuxCaseStore_forventMelosysEessiMelding() throws Exception {
+    void finnVedJournalpostIDOpprettMelosysEessiMelding_sakEksistererIEuxCaseStore_forventMelosysEessiMelding() {
         when(journalpostSedKoblingRepository.findByJournalpostID(anyString()))
                 .thenReturn(Optional.empty());
         when(caseStoreConsumer.finnVedJournalpostID(anyString()))

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sak/SakServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sak/SakServiceTest.java
@@ -1,21 +1,23 @@
 package no.nav.melosys.eessi.service.sak;
 
 import java.util.Optional;
+
 import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.integration.sak.SakConsumer;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SakServiceTest {
+@ExtendWith(MockitoExtension.class)
+class SakServiceTest {
 
     @Mock
     private SakConsumer sakConsumer;
@@ -24,20 +26,20 @@ public class SakServiceTest {
 
     private SakService sakService;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         sakService = new SakService(sakConsumer, saksrelasjonService);
         when(sakConsumer.getSak(anyString())).thenReturn(new Sak());
     }
 
     @Test
-    public void hentSak_forventSak() throws Exception{
+    void hentSak_forventSak() {
         Sak sak = sakService.hentsak(1L);
         assertThat(sak).isNotNull();
     }
 
     @Test
-    public void finnSakForRinaSaksnummer_saksrelasjonLagret_forventSak() throws Exception {
+    void finnSakForRinaSaksnummer_saksrelasjonLagret_forventSak() {
         FagsakRinasakKobling fagsakRinasakKobling = new FagsakRinasakKobling();
         fagsakRinasakKobling.setGsakSaksnummer(123L);
         when(saksrelasjonService.søkEtterSaksnummerFraRinaSaksnummer(anyString())).thenReturn(Optional.of(123L));
@@ -45,7 +47,7 @@ public class SakServiceTest {
     }
 
     @Test
-    public void finnSakForRinaSaksnummer_saksrelasjonLagretHosEux_forventSak() throws Exception {
+    void finnSakForRinaSaksnummer_saksrelasjonLagretHosEux_forventSak() {
         when(saksrelasjonService.søkEtterSaksnummerFraRinaSaksnummer(anyString())).thenReturn(Optional.of(123L));
         assertThat(sakService.finnSakForRinaSaksnummer("123321")).isPresent();
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonServiceTest.java
@@ -10,20 +10,21 @@ import no.nav.melosys.eessi.integration.sak.SakConsumer;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.repository.FagsakRinasakKoblingRepository;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class SaksrelasjonServiceTest {
+@ExtendWith(MockitoExtension.class)
+class SaksrelasjonServiceTest {
 
     @Mock
     private FagsakRinasakKoblingRepository fagsakRinasakKoblingRepository;
@@ -36,7 +37,7 @@ public class SaksrelasjonServiceTest {
 
     private SaksrelasjonService saksrelasjonService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         saksrelasjonService = new SaksrelasjonService(fagsakRinasakKoblingRepository, caseStoreConsumer, sakConsumer, applicationEventPublisher);
     }
@@ -44,20 +45,20 @@ public class SaksrelasjonServiceTest {
     private final String RINA_ID = "321";
 
     @Test
-    public void lagre_bucErIkkeLovvalg_oppdatertEuxCaseStore() {
+    void lagre_bucErIkkeLovvalg_oppdatertEuxCaseStore() {
         when(caseStoreConsumer.finnVedRinaSaksnummer(anyString())).thenReturn(Collections.emptyList());
         saksrelasjonService.lagreKobling(123L, "321", BucType.H_BUC_01);
-        verify(caseStoreConsumer).lagre(eq("123"), eq("321"));
+        verify(caseStoreConsumer).lagre("123", "321");
     }
 
     @Test
-    public void lagreKobling_verifiserRepositoryKall() {
+    void lagreKobling_verifiserRepositoryKall() {
         saksrelasjonService.lagreKobling(123L, RINA_ID, BucType.LA_BUC_04);
         verify(fagsakRinasakKoblingRepository).save(any(FagsakRinasakKobling.class));
     }
 
     @Test
-    public void lagreKobling_ikkeLovvalgBucSakEksistererICaseStore_oppdaterCaseStore() {
+    void lagreKobling_ikkeLovvalgBucSakEksistererICaseStore_oppdaterCaseStore() {
         CaseStoreDto caseStoreDto = new CaseStoreDto(1L, "bucid", "saksnummer", "rinasaksnummer", "journalpostid", "tema");
         when(sakConsumer.getSak(anyString())).thenReturn(new Sak());
         when(caseStoreConsumer.finnVedRinaSaksnummer(anyString())).thenReturn(Collections.singletonList(caseStoreDto));
@@ -66,25 +67,25 @@ public class SaksrelasjonServiceTest {
     }
 
     @Test
-    public void finnVedRinaId_verifiserRepositoryKall() {
+    void finnVedRinaId_verifiserRepositoryKall() {
         saksrelasjonService.finnVedRinaSaksnummer(RINA_ID);
-        verify(fagsakRinasakKoblingRepository).findByRinaSaksnummer(eq(RINA_ID));
+        verify(fagsakRinasakKoblingRepository).findByRinaSaksnummer(RINA_ID);
     }
 
     @Test
-    public void slettRinaId_verifiserRepositoryKall() {
+    void slettRinaId_verifiserRepositoryKall() {
         saksrelasjonService.slettVedRinaId(RINA_ID);
-        verify(fagsakRinasakKoblingRepository).deleteByRinaSaksnummer(eq(RINA_ID));
+        verify(fagsakRinasakKoblingRepository).deleteByRinaSaksnummer(RINA_ID);
     }
 
     @Test
-    public void finnVedGsakSaksnummer_verifiserRepositoryKall() {
+    void finnVedGsakSaksnummer_verifiserRepositoryKall() {
         saksrelasjonService.finnVedGsakSaksnummer(123L);
-        verify(fagsakRinasakKoblingRepository).findAllByGsakSaksnummer(eq(123L));
+        verify(fagsakRinasakKoblingRepository).findAllByGsakSaksnummer(123L);
     }
 
     @Test
-    public void søkEtterSaksnummerFraRinaSaksnummer_finnesIEuxCaseStore_forventSaksnummer() {
+    void søkEtterSaksnummerFraRinaSaksnummer_finnesIEuxCaseStore_forventSaksnummer() {
         final String rinaSaksnummer = "1231232";
         when(caseStoreConsumer.finnVedRinaSaksnummer(rinaSaksnummer))
                 .thenReturn(Collections.singletonList(new CaseStoreDto("123", rinaSaksnummer)));

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/helpers/A1GrunnlagMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/helpers/A1GrunnlagMapperTest.java
@@ -2,26 +2,27 @@ package no.nav.melosys.eessi.service.sed.helpers;
 
 import no.nav.melosys.eessi.controller.dto.Bestemmelse;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class A1GrunnlagMapperTest {
+class A1GrunnlagMapperTest {
 
     @Test
-    public void mapFromBestemmelse_expectString12_r() throws MappingException {
+    void mapFromBestemmelse_expectString12_r() throws MappingException {
         assertThat(A1GrunnlagMapper.mapFromBestemmelse(Bestemmelse.ART_12_1)).isEqualTo("12_r");
         assertThat(A1GrunnlagMapper.mapFromBestemmelse(Bestemmelse.ART_12_2)).isEqualTo("12_r");
     }
 
     @Test
-    public void mapFromBestemmelse_expectString16_R() throws MappingException {
+    void mapFromBestemmelse_expectString16_R() throws MappingException {
         assertThat(A1GrunnlagMapper.mapFromBestemmelse(Bestemmelse.ART_16_1)).isEqualTo("16_R");
         assertThat(A1GrunnlagMapper.mapFromBestemmelse(Bestemmelse.ART_16_2)).isEqualTo("16_R");
     }
 
     @Test
-    public void mapFromBestemmelse_expectStringAnnet() throws MappingException {
+    void mapFromBestemmelse_expectStringAnnet() throws MappingException {
         assertThat(A1GrunnlagMapper.mapFromBestemmelse(Bestemmelse.ART_11_1)).isEqualTo("annet");
         assertThat(A1GrunnlagMapper.mapFromBestemmelse(Bestemmelse.ART_13_1_a)).isEqualTo("annet");
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/helpers/SedMapperFactoryTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/helpers/SedMapperFactoryTest.java
@@ -7,26 +7,26 @@ import no.nav.melosys.eessi.models.exception.MappingException;
 import no.nav.melosys.eessi.service.sed.mapper.til_sed.SedMapper;
 import no.nav.melosys.eessi.service.sed.mapper.til_sed.lovvalg.A001Mapper;
 import no.nav.melosys.eessi.service.sed.mapper.til_sed.lovvalg.A009Mapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SedMapperFactoryTest {
+class SedMapperFactoryTest {
 
     @Test
-    public void oppslagavSedA001GirKorrektMapper() throws Exception {
+    void oppslagavSedA001GirKorrektMapper() {
         SedMapper sedMapper = SedMapperFactory.sedMapper(SedType.A001);
         assertThat(sedMapper).isInstanceOf(A001Mapper.class);
     }
 
     @Test
-    public void oppslagavSedA009GirKorrektMapper() throws Exception {
+    void oppslagavSedA009GirKorrektMapper() {
         SedMapper sedMapper = SedMapperFactory.sedMapper(SedType.A009);
         assertThat(sedMapper).isInstanceOf(A009Mapper.class);
     }
 
     @Test
-    public void oppslagAvAlleSeder_girKorrektMapper() throws MappingException {
+    void oppslagAvAlleSeder_girKorrektMapper() throws MappingException {
         var sedTyperMedMapper = List.of(
                 SedType.A001,
                 SedType.A002,

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/sed_grunnlag/SedGrunnlagMapperA003Test.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/sed_grunnlag/SedGrunnlagMapperA003Test.java
@@ -11,14 +11,14 @@ import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA003;
 import no.nav.melosys.eessi.models.sed.nav.Arbeidsgiver;
 import no.nav.melosys.eessi.models.sed.nav.Pin;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-public class SedGrunnlagMapperA003Test {
+class SedGrunnlagMapperA003Test {
     @Test
-    public void map_medUtfyltNav_forventVerdier() throws IOException {
+    void map_medUtfyltNav_forventVerdier() throws IOException {
         SedGrunnlagDto sedGrunnlagDto = new SedGrunnlagMapperA003().map(hentSed());
 
         assertThat(sedGrunnlagDto).isNotNull();
@@ -83,7 +83,7 @@ public class SedGrunnlagMapperA003Test {
     }
 
     @Test
-    public void map_ingenBostedsadresse_forventPostadresse() throws IOException {
+    void map_ingenBostedsadresse_forventPostadresse() throws IOException {
         SED sed = hentSed();
         var adresse = sed.getNav().getBruker().getAdresse().get(0);
         adresse.setType(Adressetype.POSTADRESSE.getAdressetypeRina());
@@ -95,15 +95,15 @@ public class SedGrunnlagMapperA003Test {
     }
 
     @Test
-    public void map_ingenAdresse_forventTomAdresse() throws IOException {
+    void map_ingenAdresse_forventTomAdresse() throws IOException {
         SED sed = hentSed();
         sed.getNav().getBruker().setAdresse(List.of());
 
-        assertThat(new SedGrunnlagMapperA003().map(sed).getBostedsadresse()).isEqualToComparingFieldByField(new Adresse());
+        assertThat(new SedGrunnlagMapperA003().map(sed).getBostedsadresse()).isEqualTo(new Adresse());
     }
 
     @Test
-    public void map_kunNorskIdent_forventTomListeAvUtenlandskeIdenter() throws IOException {
+    void map_kunNorskIdent_forventTomListeAvUtenlandskeIdenter() throws IOException {
         SED sed = hentSed();
         Pin pin = sed.getNav().getBruker().getPerson().getPin().iterator().next();
         pin.setLand("NO");
@@ -113,7 +113,7 @@ public class SedGrunnlagMapperA003Test {
     }
 
     @Test
-    public void map_ingenGate_forventKunBygning() throws IOException {
+    void map_ingenGate_forventKunBygning() throws IOException {
         SED sed = hentSed();
         var adresse = sed.getNav().getBruker().getAdresse().get(0);
         adresse.setGate(null);
@@ -123,7 +123,7 @@ public class SedGrunnlagMapperA003Test {
     }
 
     @Test
-    public void map_ingenBygning_forventKunGate() throws IOException {
+    void map_ingenBygning_forventKunGate() throws IOException {
         SED sed = hentSed();
         var adresse = sed.getNav().getBruker().getAdresse().get(0);
         adresse.setBygning(null);
@@ -133,7 +133,7 @@ public class SedGrunnlagMapperA003Test {
     }
 
     @Test
-    public void map_ingenArbeidsgiverAdresse_forventIkkeNorskArbeidsgiver() throws IOException {
+    void map_ingenArbeidsgiverAdresse_forventIkkeNorskArbeidsgiver() throws IOException {
         Consumer<Arbeidsgiver> settTomAdresse = (Arbeidsgiver arbeidsgiver) -> arbeidsgiver.setAdresse(null);
 
         SED sed = hentSed();
@@ -144,7 +144,7 @@ public class SedGrunnlagMapperA003Test {
     }
 
     @Test
-    public void map_norskArbeidsgiverNullIdentifikator_forventIngenIdentifikator() throws IOException {
+    void map_norskArbeidsgiverNullIdentifikator_forventIngenIdentifikator() throws IOException {
         SED sed = hentSed();
         ((MedlemskapA003) sed.getMedlemskap()).getAndreland().getArbeidsgiver().iterator().next().setIdentifikator(null);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/administrativ/X001MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/administrativ/X001MapperTest.java
@@ -8,14 +8,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.sed.SED;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class X001MapperTest {
+class X001MapperTest {
 
     @Test
-    public void mapFraSed() throws Exception {
+    void mapFraSed() throws Exception {
 
         URL jsonUrl = getClass().getClassLoader().getResource("mock/sedA009.json");
 
@@ -25,9 +25,8 @@ public class X001MapperTest {
         X001Mapper mapper = new X001Mapper();
         SED x001 = mapper.mapFraSed(fraSed, "aarsaken");
 
-        assertThat(x001).isNotNull();
-        assertThat(x001.getMedlemskap()).isNull();
-        assertThat(x001.getSedType()).isEqualTo(SedType.X001.name());
+        assertThat(x001).extracting(SED::getSedType, SED::getMedlemskap)
+                .containsExactly(SedType.X001.name(), null);
 
         //Påkrevde felter
         assertThat(x001.getNav().getSak().getKontekst().getBruker().getPerson().getFornavn()).isNotNull();

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/horisontal/HorisontalSedMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/horisontal/HorisontalSedMapperTest.java
@@ -9,24 +9,24 @@ import no.nav.melosys.eessi.models.exception.MappingException;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HorisontalSedMapperTest {
+class HorisontalSedMapperTest {
 
-    private HorisontalSedMapper h005Mapper = new HorisontalSedMapper(SedType.H005);
+    private final HorisontalSedMapper h005Mapper = new HorisontalSedMapper(SedType.H005);
 
     private SedDataDto sedData;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException, URISyntaxException {
         sedData = SedDataStub.getStub();
     }
 
     @Test
-    public void mapTilSed() throws MappingException, NotFoundException {
+    void mapTilSed() throws MappingException, NotFoundException {
         SED h005 = h005Mapper.mapTilSed(sedData);
 
         assertThat(h005).isNotNull();

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001MapperTest.java
@@ -14,12 +14,9 @@ import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA001;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 class A001MapperTest {
 
     private final A001Mapper a001Mapper = new A001Mapper();

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A001MapperTest.java
@@ -12,22 +12,21 @@ import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA001;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-public class A001MapperTest {
+class A001MapperTest {
 
-    private A001Mapper a001Mapper = new A001Mapper();
+    private final A001Mapper a001Mapper = new A001Mapper();
 
     private SedDataDto sedData;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException, URISyntaxException {
         sedData = SedDataStub.getStub();
 
@@ -41,10 +40,10 @@ public class A001MapperTest {
     }
 
     @Test
-    public void mapTilSed() throws MappingException, NotFoundException {
+    void mapTilSed() throws MappingException, NotFoundException {
         SED sed = a001Mapper.mapTilSed(sedData);
 
-        assertEquals(MedlemskapA001.class, sed.getMedlemskap().getClass());
+        assertThat(sed.getMedlemskap()).isInstanceOf(MedlemskapA001.class);
 
         assertThat(sed.getMedlemskap()).isNotNull().isInstanceOf(MedlemskapA001.class);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A002MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A002MapperTest.java
@@ -8,20 +8,20 @@ import no.nav.melosys.eessi.controller.dto.Periode;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.controller.dto.SvarAnmodningUnntakDto;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA002;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.SvarAnmodningUnntakBeslutning;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class A002MapperTest {
-    private A002Mapper a002Mapper = new A002Mapper();
+class A002MapperTest {
+    private final A002Mapper a002Mapper = new A002Mapper();
 
     @Test
-    public void mapTilSed_forventSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
+    void mapTilSed_forventSed() throws IOException, URISyntaxException {
         SedDataDto sedData = SedDataStub.getStub();
         SvarAnmodningUnntakDto svarAnmodningUnntakDto = new SvarAnmodningUnntakDto(
                 SvarAnmodningUnntakBeslutning.AVSLAG,
@@ -35,9 +35,11 @@ public class A002MapperTest {
         assertThat(a002.getMedlemskap()).isInstanceOf(MedlemskapA002.class);
     }
 
-    @Test(expected = MappingException.class)
-    public void mapTilSed_utenSvarAnmodningUnntak_forventException() throws MappingException, NotFoundException, IOException, URISyntaxException {
+    @Test
+    void mapTilSed_utenSvarAnmodningUnntak_forventException() throws IOException, URISyntaxException {
         SedDataDto sedData = SedDataStub.getStub();
-        a002Mapper.mapTilSed(sedData);
+        assertThatExceptionOfType(MappingException.class)
+                .isThrownBy(() -> a002Mapper.mapTilSed(sedData))
+                .withMessageContaining("Trenger SvarAnmodningUnntak");
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A004MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A004MapperTest.java
@@ -6,24 +6,19 @@ import java.net.URISyntaxException;
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.controller.dto.UtpekingAvvisDto;
 import no.nav.melosys.eessi.models.exception.MappingException;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA004;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class A004MapperTest {
-    private A004Mapper a004Mapper = new A004Mapper();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+class A004MapperTest {
+    private final A004Mapper a004Mapper = new A004Mapper();
 
     @Test
-    public void mapTilSed_forventSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
+    void mapTilSed_forventSed() throws IOException, URISyntaxException {
         SedDataDto sedData = SedDataStub.getStub();
         UtpekingAvvisDto utpekingAvvisDto = new UtpekingAvvisDto(
             "DK",
@@ -38,10 +33,9 @@ public class A004MapperTest {
     }
 
     @Test
-    public void mapTilSed_utenUtpekingAvvis_forventException() throws IOException, URISyntaxException, MappingException, NotFoundException {
+    void mapTilSed_utenUtpekingAvvis_forventException() throws IOException, URISyntaxException {
         SedDataDto sedData = SedDataStub.getStub();
-
-        expectedException.expect(MappingException.class);
-        expectedException.expectMessage("Trenger UtpekingAvvis for å opprette A004");
-        a004Mapper.mapTilSed(sedData);
+        assertThatExceptionOfType(MappingException.class)
+                .isThrownBy(() -> a004Mapper.mapTilSed(sedData))
+                .withMessageContaining("Trenger UtpekingAvvis for å opprette A004");
     }}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A005MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A005MapperTest.java
@@ -9,16 +9,16 @@ import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA005;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class A005MapperTest {
+class A005MapperTest {
 
-    private final LovvalgSedMapper sedMapper = new A005Mapper();
+    private final A005Mapper sedMapper = new A005Mapper();
 
     @Test
-    public void mapTilSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
+    void mapTilSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
         SedDataDto sedDataDto = SedDataStub.getStub();
         SED sed = sedMapper.mapTilSed(sedDataDto);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A008MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A008MapperTest.java
@@ -9,24 +9,24 @@ import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA008;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class A008MapperTest {
+class A008MapperTest {
 
-    private A008Mapper a008Mapper = new A008Mapper();
+    private final A008Mapper a008Mapper = new A008Mapper();
 
     private SedDataDto sedData;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException, URISyntaxException {
         sedData = SedDataStub.getStub();
     }
 
     @Test
-    public void mapTilSed() throws MappingException, NotFoundException {
+    void mapTilSed() throws MappingException, NotFoundException {
         SED sed = a008Mapper.mapTilSed(sedData);
         assertThat(sed.getMedlemskap()).isInstanceOf(MedlemskapA008.class);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A011MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A011MapperTest.java
@@ -7,25 +7,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA011;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class A011MapperTest {
+class A011MapperTest {
 
-    private A011Mapper a011Mapper = new A011Mapper();
+    private final A011Mapper a011Mapper = new A011Mapper();
 
     private SED a001;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         URL jsonUrl = getClass().getClassLoader().getResource("mock/sedA001.json");
         a001 = new ObjectMapper().readValue(jsonUrl, SED.class);
     }
 
     @Test
-    public void mapFraEksisterendeSedA001() {
+    void mapFraEksisterendeSedA001() {
         SED a011 = a011Mapper.mapFraSed(a001);
 
         assertThat(a011.getSedType()).isEqualToIgnoringCase(SedType.A011.toString());

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A012MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A012MapperTest.java
@@ -9,15 +9,15 @@ import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA012;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class A012MapperTest {
-    private A012Mapper a012Mapper = new A012Mapper();
+class A012MapperTest {
+    private final A012Mapper a012Mapper = new A012Mapper();
 
     @Test
-    public void mapTilSed_forventSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
+    void mapTilSed_forventSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
         SedDataDto sedData = SedDataStub.getStub();
         SED a012 = a012Mapper.mapTilSed(sedData);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sts/RestStsServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sts/RestStsServiceTest.java
@@ -16,7 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -46,7 +46,7 @@ class RestStsServiceTest {
         body.put("access_token", "123abc");
         body.put("expires_in", 30L);
 
-        ResponseEntity<Map> responseEntity = new ResponseEntity<>(body, HttpStatus.OK);
+        ResponseEntity<Map<String, Object>> responseEntity = new ResponseEntity<>(body, HttpStatus.OK);
 
         when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(
                 ParameterizedTypeReference.class)))
@@ -55,8 +55,7 @@ class RestStsServiceTest {
         String token = restStsService.collectToken();
         verify(restTemplate, times(1))
                 .exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class));
-        assertNotNull(token);
-        assertFalse(token.isEmpty());
+        assertThat(token).isNotEmpty();
 
         body.put("access_token", "cba321");
         body.put("expires_in", 3600L);
@@ -64,13 +63,13 @@ class RestStsServiceTest {
         String secondToken = restStsService.collectToken();
         verify(restTemplate, times(2))
                 .exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class));
-        assertNotEquals(token, secondToken);
+        assertThat(token).isNotEqualTo(secondToken);
 
         body.put("access_token", "abccba");
 
         String thirdToken = restStsService.collectToken();
         verify(restTemplate, times(2))
                 .exchange(anyString(), any(), any(), any(ParameterizedTypeReference.class));
-        assertEquals(secondToken, thirdToken);
+        assertThat(secondToken).isEqualTo(thirdToken);
     }
 }

--- a/melosys-eessi-test/pom.xml
+++ b/melosys-eessi-test/pom.xml
@@ -39,13 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>no.finn.unleash</groupId>
             <artifactId>unleash-client-java</artifactId>
             <version>${unleash.version}</version>


### PR DESCRIPTION
..men fikk ikke til å fjerne junit4 helt, da det fortsatt kommer som en transitiv avhengighet gjennom token-support og videre i okhttp3. Prøvde å fikle litt og erstatte dette med `mockwebserver-junit5`, men det ble bare rot.