### PR TITLE
Fix for maks én identifisering oppgave

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.java]
+ij_java_imports_layout = java.**,javax.**,|,*,|,$*
+ij_java_layout_static_imports_separately = true
+ij_java_class_count_to_use_import_on_demand = 5
+ij_java_names_count_to_use_import_on_demand = 3
+
+[{.babelrc, .stylelintrc, .eslintrc, jest.config, *.bowerrc, *.jsb3, *.jsb2, *.json}]
+indent_size = 2
+
+[{*.yml, *.yaml}]
+indent_size = 2

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BucIdentifiseringService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BucIdentifiseringService.java
@@ -39,6 +39,7 @@ public class BucIdentifiseringService {
                 .map(Object::toString)
                 .orElse(null);
 
+        log.info("Publiserer melding om SED mottatt. SED: {}", sedMottattHendelse.getSedHendelse().getSedId());
         melosysEessiProducer.publiserMelding(
                 mapper.map(
                         aktørID,

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
@@ -29,15 +29,15 @@ public class OppgaveEndretConsumer {
             topics = "${melosys.kafka.consumer.oppgave-endret.topic}",
             containerFactory = "oppgaveListenerContainerFactory")
     public void oppgaveEndret(ConsumerRecord<String, OppgaveEndretHendelse> consumerRecord) {
-        log.debug("Oppgave endret: {}", consumerRecord.value());
         final var oppgave = consumerRecord.value();
+        log.debug("Oppgave endret: {}", oppgave);
 
         if (erIdentifisertOppgave(oppgave)) {
             log.info("Oppgave {} markert som identifisert. Søker etter tilknyttet RINA-sak", oppgave.getId());
-            bucIdentifiseringOppgRepository.findByOppgaveId(consumerRecord.value().getId().toString())
+            bucIdentifiseringOppgRepository.findByOppgaveId(oppgave.getId().toString())
                     .ifPresent(b -> {
                         log.info("BUC {} identifisert av oppgave {}", b.getRinaSaksnummer(), b.getOppgaveId());
-                        eventPublisher.publishEvent(new BucIdentifisertEvent(b.getRinaSaksnummer(), consumerRecord.value().hentAktørID()));
+                        eventPublisher.publishEvent(new BucIdentifisertEvent(b.getRinaSaksnummer(), oppgave.hentAktørID()));
                         oppgaveService.ferdigstillOppgave(b.getOppgaveId(), oppgave.getVersjon());
                     });
         }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
@@ -33,6 +33,7 @@ public class OppgaveEndretConsumer {
         final var oppgave = consumerRecord.value();
 
         if (erIdentifisertOppgave(oppgave)) {
+            log.info("Oppgave {} markert som identifisert. Søker etter tilknyttet RINA-sak", oppgave.getId());
             bucIdentifiseringOppgRepository.findByOppgaveId(consumerRecord.value().getId().toString())
                     .ifPresent(b -> {
                         log.info("BUC {} identifisert av oppgave {}", b.getRinaSaksnummer(), b.getOppgaveId());

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretHendelse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretHendelse.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
@@ -40,6 +41,7 @@ public class OppgaveEndretHendelse {
     public static class Ident {
         private String identType;
         private String verdi;
+        @ToString.Exclude
         private String folkeregisterident;
     }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonSok.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonSok.java
@@ -57,7 +57,6 @@ class PersonSok {
         } else if (!harOverlappendeStatsborgerskap(person, personsokKriterier)) {
             return SoekBegrunnelse.FEIL_STATSBORGERSKAP;
         } else if (!harSammeFoedselsdato(person, personsokKriterier)) {
-            log.info("Fra PDL: {} ------- søkekriterier: {}", person.getFødselsdato(), personsokKriterier.getFoedselsdato());
             return SoekBegrunnelse.FEIL_FOEDSELSDATO;
         }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/RestUtils.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/RestUtils.java
@@ -20,28 +20,28 @@ public class RestUtils {
     private static final String OPPGAVE_FEIL_KEY = "feilmelding";
 
     public static String hentFeilmeldingForEux(RestClientException e) {
-        return hentFeilmelding(e, EUX_FEIL_KEY);
-    }
-
-    public static String hentFeilmeldingForOppgave(RestClientException e) {
-        return hentFeilmelding(e, OPPGAVE_FEIL_KEY);
-    }
-
-    private static String hentFeilmelding(RestClientException e, String nøkkel) {
         if(e instanceof RestClientResponseException) {
             RestClientResponseException clientErrorException = (RestClientResponseException) e;
-            String feilmelding = clientErrorException.getResponseBodyAsString();
+            var feilmelding = clientErrorException.getResponseBodyAsString();
             if (!StringUtils.hasText(feilmelding)) return e.getMessage();
-            try {
-                JsonNode json = objectMapper.readTree(feilmelding).path(nøkkel);
-                return json.isMissingNode() ? e.getMessage() : json.toString();
-            } catch (IOException ex) {
-                log.warn("Kunne ikke lese feilmelding fra response", ex);
-                return clientErrorException.getResponseBodyAsString();
-            }
+            return hentFeilmelding(feilmelding, EUX_FEIL_KEY);
         }
 
         return e.getMessage();
+    }
+
+    public static String hentFeilmeldingForOppgave(String feilmelding) {
+        return hentFeilmelding(feilmelding, OPPGAVE_FEIL_KEY);
+    }
+
+    private static String hentFeilmelding(String feilmelding, String nøkkel) {
+        try {
+            JsonNode json = objectMapper.readTree(feilmelding).path(nøkkel);
+            return json.isMissingNode() ? feilmelding : json.toString();
+        } catch (IOException ex) {
+            log.warn("Kunne ikke lese feilmelding fra response", ex);
+            return feilmelding;
+        }
     }
 
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/oppgave/OppgaveConsumerProducer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/oppgave/OppgaveConsumerProducer.java
@@ -1,12 +1,14 @@
 package no.nav.melosys.eessi.integration.oppgave;
 
-import no.nav.melosys.eessi.security.SystemContextClientRequestInterceptor;
+import java.util.Collections;
+
+import no.nav.melosys.eessi.security.SystemContextRequestFilter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class OppgaveConsumerProducer {
@@ -18,11 +20,18 @@ public class OppgaveConsumerProducer {
     }
 
     @Bean
-    public OppgaveConsumer oppgaveConsumer(SystemContextClientRequestInterceptor systemContextClientRequestInterceptor) {
-        RestTemplate restTemplate = new RestTemplateBuilder()
-                .uriTemplateHandler(new DefaultUriBuilderFactory(url))
-                .interceptors(systemContextClientRequestInterceptor)
-                .build();
-        return new OppgaveConsumer(restTemplate);
+    public OppgaveConsumer oppgaveConsumer(WebClient.Builder webClientBuilder, SystemContextRequestFilter systemContextRequestFilter) {
+        return new OppgaveConsumer(
+                webClientBuilder
+                        .baseUrl(url)
+                        .defaultHeaders(this::defaultHeaders)
+                        .filter(systemContextRequestFilter)
+                        .build()
+        );
+    }
+
+    private void defaultHeaders(HttpHeaders httpHeaders) {
+        httpHeaders.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/oppgave/OppgaveDto.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/oppgave/OppgaveDto.java
@@ -8,10 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Data
 @AllArgsConstructor
@@ -36,6 +33,7 @@ public class OppgaveDto {
     private String temagruppe;
     private String tildeltEnhetsnr;
     private String behandlesAvApplikasjon;
+    @ToString.Exclude
     private String beskrivelse;
     private Map<OppgaveMetadataKey, String> metadata = new EnumMap<>(OppgaveMetadataKey.class);
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/SedHendelse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/SedHendelse.java
@@ -1,10 +1,7 @@
 package no.nav.melosys.eessi.kafka.consumers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -23,6 +20,7 @@ public class SedHendelse {
     private String rinaDokumentId;
     private String rinaDokumentVersjon;
     private String sedType;
+    @ToString.Exclude
     private String navBruker;
 
     // avsenderID har formatet <landkodeISO2>:<institusjonID>

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/SystemContextRequestFilter.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/SystemContextRequestFilter.java
@@ -1,0 +1,33 @@
+package no.nav.melosys.eessi.security;
+
+import javax.annotation.Nonnull;
+
+import no.nav.melosys.eessi.service.sts.RestStsService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SystemContextRequestFilter implements ExchangeFilterFunction {
+
+    private final RestStsService restStsService;
+
+    public SystemContextRequestFilter(RestStsService restStsService) {
+        this.restStsService = restStsService;
+    }
+
+    @Nonnull
+    @Override
+    public Mono<ClientResponse> filter(@Nonnull ClientRequest clientRequest,
+                                       @Nonnull ExchangeFunction exchangeFunction) {
+        return exchangeFunction.exchange(
+                ClientRequest.from(clientRequest)
+                        .header(HttpHeaders.AUTHORIZATION, restStsService.bearerToken())
+                        .build()
+        );
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/oppgave/OppgaveService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/oppgave/OppgaveService.java
@@ -1,12 +1,10 @@
 package no.nav.melosys.eessi.service.oppgave;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
-import no.nav.melosys.eessi.integration.oppgave.HentOppgaveDto;
-import no.nav.melosys.eessi.integration.oppgave.OppgaveConsumer;
-import no.nav.melosys.eessi.integration.oppgave.OppgaveDto;
-import no.nav.melosys.eessi.integration.oppgave.OppgaveOppdateringDto;
+import no.nav.melosys.eessi.integration.oppgave.*;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import org.springframework.stereotype.Service;
 
@@ -43,6 +41,7 @@ public class OppgaveService {
                 .tema(temaForSedType(sedType))
                 .tildeltEnhetsnr(ENHET_ID_FORDELING)
                 .beskrivelse(String.format(BESKRIVELSE, sedType, rinaSaksnummer))
+                .metadata(Map.of(OppgaveMetadataKey.RINA_SAKID, rinaSaksnummer))
                 .build();
 
         HentOppgaveDto response = oppgaveConsumer.opprettOppgave(oppgaveDto);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/oppgave/OppgaveConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/oppgave/OppgaveConsumerTest.java
@@ -1,80 +1,81 @@
 package no.nav.melosys.eessi.integration.oppgave;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpMethod;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 class OppgaveConsumerTest {
-
-    private MockRestServiceServer server;
-    private final RestTemplate restTemplate = new RestTemplate();
 
     private OppgaveConsumer oppgaveConsumer;
 
     private final String OPPGAVE_ID = "123";
 
+    private static MockWebServer mockWebServer;
+    private static String rootUri;
+
+    @BeforeAll
+    static void setupAll() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        rootUri = String.format("http://localhost:%s", mockWebServer.getPort());
+    }
+
     @BeforeEach
     public void setUp() {
-        server = MockRestServiceServer.createServer(restTemplate);
+        RestTemplate restTemplate = new RestTemplateBuilder().rootUri(rootUri).build();
         oppgaveConsumer = new OppgaveConsumer(restTemplate);
     }
 
     @Test
-    void hentOppgave_oppgaveFinnes_verifiserMapping() {
-        server.expect(requestTo("/oppgaver/" + OPPGAVE_ID))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON).body(hentOppgaveResponse()));
+    void hentOppgave_oppgaveFinnes_verifiserMapping() throws InterruptedException {
+        mockWebServer.enqueue(
+                new MockResponse()
+                        .setBody(hentOppgaveResponse())
+                        .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        );
+
         var oppgave = oppgaveConsumer.hentOppgave(OPPGAVE_ID);
-
-        assertThat(oppgave)
-                .extracting(
-                        HentOppgaveDto::getStatuskategori,
-                        HentOppgaveDto::getAktoerId,
-                        HentOppgaveDto::getTema
-                ).containsExactly(
-                "AAPEN",
-                "1332607802528",
-                "MED"
-        );
+        assertOppgaveFelter(oppgave);
+        assertThat(mockWebServer.takeRequest())
+                .extracting(RecordedRequest::getPath, RecordedRequest::getMethod)
+                .containsExactly("/oppgaver/" + OPPGAVE_ID, "GET");
     }
 
     @Test
-    void opprettOppgave_verifiserMapping() {
-        server.expect(requestTo("/oppgaver"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON).body(hentOppgaveResponse()));
-        var oppgaveDto = opprettOppgave();
-        var oppgave = oppgaveConsumer.opprettOppgave(oppgaveDto);
-
-        assertThat(oppgave)
-                .extracting(
-                        OppgaveDto::getJournalpostId,
-                        OppgaveDto::getAktoerId,
-                        OppgaveDto::getTema,
-                        OppgaveDto::getTildeltEnhetsnr
-                ).containsExactly(
-                oppgave.getJournalpostId(),
-                oppgave.getAktoerId(),
-                oppgave.getTema(),
-                oppgave.getTildeltEnhetsnr()
+    void opprettOppgave_verifiserMapping() throws InterruptedException {
+        mockWebServer.enqueue(
+                new MockResponse()
+                        .setBody(hentOppgaveResponse())
+                        .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         );
+
+        var oppgave = oppgaveConsumer.opprettOppgave(opprettOppgave());
+        assertOppgaveFelter(oppgave);
+        assertThat(mockWebServer.takeRequest())
+                .extracting(RecordedRequest::getPath, RecordedRequest::getMethod)
+                .containsExactly("/oppgaver", "POST");
     }
 
     @Test
-    void oppdaterOppgave_utenBeskrivelse_beksrivelseMappesIkkeTilRequest() {
+    void oppdaterOppgave_utenBeskrivelse_beksrivelseMappesIkkeTilRequest() throws InterruptedException, JsonProcessingException {
         final var forventetJsonBodyRequestUtenBeskrivelseFelt = """
                 {
                     "id": 1,
@@ -83,13 +84,30 @@ class OppgaveConsumerTest {
                 }
                 """;
 
-        server.expect(requestTo("/oppgaver/" + OPPGAVE_ID))
-                .andExpect(method(HttpMethod.PATCH))
-                .andExpect(content().json(forventetJsonBodyRequestUtenBeskrivelseFelt))
-                .andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON).body(hentOppgaveResponse()));
+        mockWebServer.enqueue(
+                new MockResponse()
+                        .setBody(hentOppgaveResponse())
+                        .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        );
 
         var oppgaveOppdateringDto = OppgaveOppdateringDto.builder().id(1).versjon(2).status("status").build();
-        assertThat(oppgaveConsumer.oppdaterOppgave(OPPGAVE_ID, oppgaveOppdateringDto)).isNotNull();
+        assertOppgaveFelter(oppgaveConsumer.oppdaterOppgave(OPPGAVE_ID, oppgaveOppdateringDto));
+
+        var request = mockWebServer.takeRequest();
+        var requestBody = request.getBody().readUtf8();
+        assertThat(request)
+                .extracting(RecordedRequest::getPath, RecordedRequest::getMethod)
+                .containsExactly("/oppgaver/" + OPPGAVE_ID, "PATCH");
+
+        var objectMapper = new ObjectMapper();
+        assertThat(objectMapper.readTree(requestBody))
+                .isEqualTo(objectMapper.readTree(forventetJsonBodyRequestUtenBeskrivelseFelt));
+    }
+
+    private void assertOppgaveFelter(HentOppgaveDto oppgaveDto) {
+        assertThat(oppgaveDto)
+                .extracting(HentOppgaveDto::getStatuskategori, HentOppgaveDto::getAktoerId, HentOppgaveDto::getTema)
+                .containsExactly("AAPEN", "1332607802528", "MED");
     }
 
     private OppgaveDto opprettOppgave() {


### PR DESCRIPTION
Småfiksing ifbm MELOSYS-4435. Hovedsakelig to ting som manglet:

- Sette RINA-saksnummer som metadata i oppgaven som opprettes til ID og Fordeling
- Http-method PATCH støttes ikke "ut av boksen" av Java, og kall med PATCH feilet med OppgaveConsumer sin RestTemplate. Hovedgrunnen til dette er nok at melosys-eessi ikke lar den bli konfigurert av Spring. Jeg skrev om testene for å fremprovosere problemet (noe som ikke gikk..), og da skrev jeg like gjerne om fra RestTemplate til WebClient mens jeg var i gang.. 🙃 

Også litt småforbedringer med f.eks. logging av korrelasjonsid mot Oppgave og ignorering av enkelte felter fra autogenerert toString av Lombok.