### PR TITLE
No jira fix arkivert rinasak

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/buc/LukkBucService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/buc/LukkBucService.java
@@ -42,7 +42,7 @@ public class LukkBucService {
                     .filter(BucInfo::bucErÅpen)
                     .filter(BucInfo::norgeErCaseOwner)
                     .map(BucInfo::getId)
-                    .map(this::finnBuc)
+                    .map(euxService::finnBUC)
                     .flatMap(Optional::stream)
                     .filter(Objects::nonNull)
                     .filter(BUC::kanLukkesAutomatisk)
@@ -59,7 +59,7 @@ public class LukkBucService {
      */
     public void forsøkLukkBucAsync(final String rinaSaksnummer) {
         try {
-            finnBuc(rinaSaksnummer)
+            euxService.finnBUC(rinaSaksnummer)
                     .filter(b -> b.kanOppretteEllerOppdatereSed(SedType.X001))
                     .ifPresentOrElse(
                             this::lukkBuc,
@@ -107,14 +107,6 @@ public class LukkBucService {
                 .min(documentComparator)
                 .map(d -> euxService.hentSed(buc.getId(), d.getId()))
                 .orElseThrow(() -> new IllegalStateException("Finner ingen lovvalgs-SED på buc" + buc.getId()));
-    }
-
-    private Optional<BUC> finnBuc(String rinaSaksnummer) {
-        try {
-            return Optional.of(euxService.hentBuc(rinaSaksnummer));
-        } catch (IntegrationException ex) {
-            return Optional.empty();
-        }
     }
 
     private static final Comparator<Document> documentComparator = Comparator.comparing(Document::getCreationDate);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxService.java
@@ -2,6 +2,7 @@ package no.nav.melosys.eessi.service.eux;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,8 @@ import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.SedVedlegg;
 import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.bucinfo.BucInfo;
+import no.nav.melosys.eessi.models.exception.IntegrationException;
+import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
 import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
@@ -111,8 +114,20 @@ public class EuxService {
         return euxConsumer.finnRinaSaker(bucSearch.getBucType(), bucSearch.getStatus());
     }
 
-    public BUC hentBuc(String rinaSakid) {
-        return euxConsumer.hentBUC(rinaSakid);
+    public BUC hentBuc(String rinaSaksnummer) {
+        return euxConsumer.hentBUC(rinaSaksnummer);
+    }
+
+    /**
+     * Kaster ikke exception om en BUC er arkivert eller ikke finnes
+     */
+    public Optional<BUC> finnBUC(String rinaSaksnummer) {
+        try {
+            return Optional.of(euxConsumer.hentBUC(rinaSaksnummer));
+        } catch (IntegrationException | NotFoundException e) {
+            log.warn("Kan ikke hente BUC {}", rinaSaksnummer, e);
+            return Optional.empty();
+        }
     }
 
     public SedMedVedlegg hentSedMedVedlegg(String rinaSaksnummer, String dokumentId) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/buc/LukkBucServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/buc/LukkBucServiceTest.java
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import io.github.benas.randombeans.api.EnhancedRandom;
 import no.nav.melosys.eessi.EnhancedRandomCreator;
@@ -62,7 +63,7 @@ class LukkBucServiceTest {
         BUC buc = lagBuc();
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(bucInfos);
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         SED sed = new SED();
         sed.setNav(enhancedRandom.nextObject(Nav.class));
@@ -72,7 +73,7 @@ class LukkBucServiceTest {
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_04);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService).hentSed(buc.getId(), buc.getDocuments().get(0).getId());
         verify(euxService).opprettOgSendSed(any(SED.class), eq(buc.getId()));
     }
@@ -97,7 +98,7 @@ class LukkBucServiceTest {
         buc.getDocuments().add(x001Doc);
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(bucInfos);
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         SED sed = new SED();
         sed.setNav(enhancedRandom.nextObject(Nav.class));
@@ -107,7 +108,7 @@ class LukkBucServiceTest {
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_04);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService).hentSed(buc.getId(), buc.getDocuments().get(0).getId());
         verify(euxService).oppdaterSed(eq(buc.getId()), eq(x001Doc.getId()), any(SED.class));
         verify(euxService).sendSed(buc.getId(), x001Doc.getId());
@@ -131,11 +132,11 @@ class LukkBucServiceTest {
         bucInfos.add(bucInfo);
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(bucInfos);
-        when(euxService.hentBuc(any())).thenThrow(new IntegrationException(""));
+        when(euxService.finnBUC(any())).thenReturn(Optional.empty());
 
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_04);
 
-        verify(euxService).hentBuc(anyString());
+        verify(euxService).finnBUC(anyString());
         verify(euxService, never()).hentSed(anyString(), anyString());
     }
 
@@ -152,13 +153,13 @@ class LukkBucServiceTest {
         BUC buc = lagBuc();
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(bucInfos);
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
         when(euxService.hentSed(anyString(), anyString())).thenThrow(new IntegrationException(""));
 
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_04);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService).hentSed(buc.getId(), buc.getDocuments().get(0).getId());
         verify(euxService, never()).opprettOgSendSed(any(), any());
     }
@@ -186,7 +187,7 @@ class LukkBucServiceTest {
         buc.getDocuments().add(document);
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(bucInfos);
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         SED sed = new SED();
         sed.setNav(enhancedRandom.nextObject(Nav.class));
@@ -196,7 +197,7 @@ class LukkBucServiceTest {
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_04);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService).hentSed(buc.getId(), sisteOppdatertDokumentId);
         verify(euxService, never()).opprettOgSendSed(any(), any());
     }
@@ -231,7 +232,7 @@ class LukkBucServiceTest {
         buc.getDocuments().add(document);
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(List.of(bucInfo));
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         SED sed = new SED();
         sed.setNav(enhancedRandom.nextObject(Nav.class));
@@ -241,7 +242,7 @@ class LukkBucServiceTest {
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_06);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService).hentSed(buc.getId(), sisteOppdatertDokumentId);
         verify(euxService).opprettOgSendSed(any(), eq(buc.getId()));
     }
@@ -258,12 +259,12 @@ class LukkBucServiceTest {
         String sisteOppdatertDokumentId = buc.getDocuments().get(0).getId();
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(List.of(bucInfo));
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_06);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService, never()).hentSed(buc.getId(), sisteOppdatertDokumentId);
         verify(euxService, never()).opprettOgSendSed(any(), eq(buc.getId()));
     }
@@ -278,12 +279,12 @@ class LukkBucServiceTest {
         BUC buc = lagBuc(BucType.LA_BUC_01, SedType.A001);
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(List.of(bucInfo));
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_01);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService, never()).hentSed(any(), any());
         verify(euxService, never()).opprettOgSendSed(any(), eq(buc.getId()));
     }
@@ -304,12 +305,12 @@ class LukkBucServiceTest {
         buc.getDocuments().add(a011);
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(List.of(bucInfo));
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_01);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService, never()).hentSed(any(), any());
         verify(euxService, never()).opprettOgSendSed(any(), eq(buc.getId()));
     }
@@ -337,12 +338,12 @@ class LukkBucServiceTest {
         when(euxService.hentSed(anyString(), anyString())).thenReturn(sed);
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(List.of(bucInfo));
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_01);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService).opprettOgSendSed(any(), eq(buc.getId()));
     }
 
@@ -357,12 +358,12 @@ class LukkBucServiceTest {
         buc.getActions().iterator().next().setDocumentType(SedType.A012.name());
 
         when(euxService.hentBucer(any(BucSearch.class))).thenReturn(List.of(bucInfo));
-        when(euxService.hentBuc(bucInfo.getId())).thenReturn(buc);
+        when(euxService.finnBUC(bucInfo.getId())).thenReturn(Optional.of(buc));
 
         lukkBucService.lukkBucerAvType(BucType.LA_BUC_01);
 
         verify(euxService).hentBucer(any(BucSearch.class));
-        verify(euxService).hentBuc(bucInfo.getId());
+        verify(euxService).finnBUC(bucInfo.getId());
         verify(euxService, never()).hentSed(any(), any());
         verify(euxService, never()).opprettOgSendSed(any(), eq(buc.getId()));
     }
@@ -373,7 +374,7 @@ class LukkBucServiceTest {
         final var buc = lagBuc();
         buc.getActions().clear();
         final var rinaSaksnummer = buc.getId();
-        when(euxService.hentBuc(rinaSaksnummer)).thenReturn(buc);
+        when(euxService.finnBUC(rinaSaksnummer)).thenReturn(Optional.of(buc));
 
         lukkBucService.forsøkLukkBucAsync(rinaSaksnummer);
 
@@ -389,7 +390,7 @@ class LukkBucServiceTest {
         sed.setMedlemskap(enhancedRandom.nextObject(MedlemskapA009.class));
 
         when(euxService.hentSed(eq(rinaSaksnummer), anyString())).thenReturn(sed);
-        when(euxService.hentBuc(rinaSaksnummer)).thenReturn(buc);
+        when(euxService.finnBUC(rinaSaksnummer)).thenReturn(Optional.of(buc));
 
         lukkBucService.forsøkLukkBucAsync(rinaSaksnummer);
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/eux/EuxServiceTest.java
@@ -74,6 +74,12 @@ class EuxServiceTest {
     }
 
     @Test
+    void finnBuc_integrasjonsfeil_tomRespons() {
+        when(euxConsumer.hentBUC("123123123")).thenThrow(new IntegrationException("err"));
+        assertThat(euxService.finnBUC("123123123")).isEmpty();
+    }
+
+    @Test
     void genererPdfFraSed_forventKonsumentkall() {
         euxService.genererPdfFraSed(new SED());
         verify(euxConsumer).genererPdfFraSed(any());

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedDataStub.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedDataStub.java
@@ -15,7 +15,7 @@ public class SedDataStub {
 
     public static SedDataDto getStub() throws IOException, URISyntaxException {
         URI søknadURI = Objects.requireNonNull(SedDataStub.class.getClassLoader().getResource("mock/sedDataDtoStub.json")).toURI();
-        String json = new String(Files.readAllBytes(Paths.get(søknadURI)));
+        String json = Files.readString(Paths.get(søknadURI));
         var objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         return objectMapper.readValue(json, SedDataDto.class);


### PR DESCRIPTION
Når er RINA-sak er arkivert, så kan ikke Melosys hente den, og det er heller ingen mulighet for å endre tilstanden på BUCen. Innfører da en metode som fanger exception og returnerer Optional ved forsøk på å hente ned en BUC.