### PR TITLE
Melosys 4435 lagre ident identifisert for BUC

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @AllArgsConstructor
-public class BucIdentifiseringService {
+public class BehandleBucIdentifisertService {
 
     private final SedMottattHendelseRepository sedMottattHendelseRepository;
     private final SaksrelasjonService saksrelasjonService;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BucIdentifisertService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BucIdentifisertService.java
@@ -42,7 +42,7 @@ public class BucIdentifisertService {
         }
 
         return bucIdentifisertRepository.findByRinaSaksnummer(rinaSaksnummer)
-            .map(BucIdentifisert::getIdent);
+            .map(BucIdentifisert::getFolkeregisterident);
     }
 
     public void lagreIdentifisertPerson(String rinaSaksnummer, String ident) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BucIdentifisertService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BucIdentifisertService.java
@@ -1,0 +1,58 @@
+package no.nav.melosys.eessi.identifisering;
+
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.melosys.eessi.identifisering.event.BucIdentifisertEvent;
+import no.nav.melosys.eessi.integration.PersonFasade;
+import no.nav.melosys.eessi.models.BucIdentifisert;
+import no.nav.melosys.eessi.repository.BucIdentifisertRepository;
+import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class BucIdentifisertService {
+
+    private final BucIdentifisertRepository bucIdentifisertRepository;
+    private final SaksrelasjonService saksrelasjonService;
+    private final PersonFasade personFasade;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public BucIdentifisertService(BucIdentifisertRepository bucIdentifisertRepository,
+                                  SaksrelasjonService saksrelasjonService,
+                                  PersonFasade personFasade,
+                                  ApplicationEventPublisher applicationEventPublisher) {
+        this.bucIdentifisertRepository = bucIdentifisertRepository;
+        this.saksrelasjonService = saksrelasjonService;
+        this.personFasade = personFasade;
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    /**
+     * Henter ident fra saksrelasjon, eller fra buc_identifisert tabell om førstnevnte ikke finnes (vil oppstå for saker eldre enn tabellen)
+     */
+    public Optional<String> finnIdentifisertPerson(String rinaSaksnummer) {
+        var ident = saksrelasjonService.finnAktørIDTilhørendeRinasak(rinaSaksnummer)
+            .map(personFasade::hentNorskIdent);
+
+        if (ident.isPresent()) {
+            return ident;
+        }
+
+        return bucIdentifisertRepository.findByRinaSaksnummer(rinaSaksnummer)
+            .map(BucIdentifisert::getIdent);
+    }
+
+    public void lagreIdentifisertPerson(String rinaSaksnummer, String ident) {
+        bucIdentifisertRepository.findByRinaSaksnummer(rinaSaksnummer)
+            .ifPresentOrElse(
+                i -> log.info("Rinasak {} allerede identifisert", rinaSaksnummer),
+                () -> {
+                    bucIdentifisertRepository.save(new BucIdentifisert(null, rinaSaksnummer, ident));
+                    applicationEventPublisher.publishEvent(new BucIdentifisertEvent(rinaSaksnummer, ident));
+                }
+            );
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/event/BucIdentifisertEvent.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/event/BucIdentifisertEvent.java
@@ -7,11 +7,11 @@ import org.springframework.context.ApplicationEvent;
 public class BucIdentifisertEvent extends ApplicationEvent {
 
     private final String bucId;
-    private final String ident;
+    private final String folkeregisterident;
 
-    public BucIdentifisertEvent(String bucId, String ident) {
+    public BucIdentifisertEvent(String bucId, String folkeregisterident) {
         super(bucId);
         this.bucId = bucId;
-        this.ident = ident;
+        this.folkeregisterident = folkeregisterident;
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/event/BucIdentifisertEvent.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/event/BucIdentifisertEvent.java
@@ -7,11 +7,11 @@ import org.springframework.context.ApplicationEvent;
 public class BucIdentifisertEvent extends ApplicationEvent {
 
     private final String bucId;
-    private final String aktørId;
+    private final String ident;
 
-    public BucIdentifisertEvent(String bucId, String aktørId) {
+    public BucIdentifisertEvent(String bucId, String ident) {
         super(bucId);
         this.bucId = bucId;
-        this.aktørId = aktørId;
+        this.ident = ident;
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/BucIdentifisert.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/BucIdentifisert.java
@@ -1,0 +1,25 @@
+package no.nav.melosys.eessi.models;
+
+import javax.persistence.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "buc_identifisert")
+public class BucIdentifisert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "rina_saksnummer", updatable = false)
+    private String rinaSaksnummer;
+
+    @Column(name = "ident", updatable = false)
+    private String ident;
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/BucIdentifisert.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/BucIdentifisert.java
@@ -20,6 +20,6 @@ public class BucIdentifisert {
     @Column(name = "rina_saksnummer", updatable = false)
     private String rinaSaksnummer;
 
-    @Column(name = "ident", updatable = false)
-    private String ident;
+    @Column(name = "folkeregisterident", updatable = false)
+    private String folkeregisterident;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/BucIdentifisertRepository.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/BucIdentifisertRepository.java
@@ -1,0 +1,10 @@
+package no.nav.melosys.eessi.repository;
+
+import java.util.Optional;
+
+import no.nav.melosys.eessi.models.BucIdentifisert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BucIdentifisertRepository extends JpaRepository<BucIdentifisert, Long> {
+    Optional<BucIdentifisert> findByRinaSaksnummer(String rinaSaksnummer);
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostService.java
@@ -9,7 +9,7 @@ import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.service.eux.EuxService;
 import no.nav.melosys.eessi.service.oppgave.OppgaveService;
-import no.nav.melosys.eessi.service.sak.SakService;
+import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -19,7 +19,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 @Service
 public class OpprettUtgaaendeJournalpostService {
 
-    private final SakService sakService;
+    private final SaksrelasjonService saksrelasjonService;
     private final JournalpostService journalpostService;
     private final EuxService euxService;
     private final PersonFasade personFasade;
@@ -27,20 +27,20 @@ public class OpprettUtgaaendeJournalpostService {
 
     @Autowired
     public OpprettUtgaaendeJournalpostService(
-            SakService sakService,
+            SaksrelasjonService saksrelasjonService,
             JournalpostService journalpostService,
             EuxService euxService,
             PersonFasade personFasade,
             OppgaveService oppgaveService) {
+        this.saksrelasjonService = saksrelasjonService;
         this.journalpostService = journalpostService;
-        this.sakService = sakService;
         this.euxService = euxService;
         this.personFasade = personFasade;
         this.oppgaveService = oppgaveService;
     }
 
     public String arkiverUtgaaendeSed(SedHendelse sedSendt) {
-        Optional<Sak> sak = sakService.finnSakForRinaSaksnummer(sedSendt.getRinaSakId());
+        Optional<Sak> sak = saksrelasjonService.finnArkivsakForRinaSaksnummer(sedSendt.getRinaSakId());
 
         if (sak.isEmpty()) {
             return arkiverUtenSak(sedSendt);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/BucIdentifisertEventListener.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/BucIdentifisertEventListener.java
@@ -2,7 +2,7 @@ package no.nav.melosys.eessi.service.mottak;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.melosys.eessi.identifisering.BucIdentifiseringService;
+import no.nav.melosys.eessi.identifisering.BehandleBucIdentifisertService;
 import no.nav.melosys.eessi.identifisering.event.BucIdentifisertEvent;
 import no.nav.melosys.eessi.integration.PersonFasade;
 import org.springframework.context.event.EventListener;
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class BucIdentifisertEventListener {
 
-    private final BucIdentifiseringService bucIdentifiseringService;
+    private final BehandleBucIdentifisertService behandleBucIdentifisertService;
     private final PersonFasade personFasade;
 
     @EventListener
     public void personIdentifisertForBuc(BucIdentifisertEvent bucIdentifisertEvent) {
         log.info("Identifiserer alle SEDer for BUC {}", bucIdentifisertEvent.getBucId());
-        bucIdentifiseringService.bucIdentifisert(
+        behandleBucIdentifisertService.bucIdentifisert(
             bucIdentifisertEvent.getBucId(),
             personFasade.hentAktoerId(bucIdentifisertEvent.getIdent())
         );

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/BucIdentifisertEventListener.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/BucIdentifisertEventListener.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.identifisering.BucIdentifiseringService;
 import no.nav.melosys.eessi.identifisering.event.BucIdentifisertEvent;
+import no.nav.melosys.eessi.integration.PersonFasade;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -13,10 +14,14 @@ import org.springframework.stereotype.Component;
 public class BucIdentifisertEventListener {
 
     private final BucIdentifiseringService bucIdentifiseringService;
+    private final PersonFasade personFasade;
 
     @EventListener
     public void personIdentifisertForBuc(BucIdentifisertEvent bucIdentifisertEvent) {
         log.info("Identifiserer alle SEDer for BUC {}", bucIdentifisertEvent.getBucId());
-        bucIdentifiseringService.bucIdentifisert(bucIdentifisertEvent.getBucId(), bucIdentifisertEvent.getAktørId());
+        bucIdentifiseringService.bucIdentifisert(
+            bucIdentifisertEvent.getBucId(),
+            personFasade.hentAktoerId(bucIdentifisertEvent.getIdent())
+        );
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/BucIdentifisertEventListener.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/BucIdentifisertEventListener.java
@@ -21,7 +21,7 @@ public class BucIdentifisertEventListener {
         log.info("Identifiserer alle SEDer for BUC {}", bucIdentifisertEvent.getBucId());
         behandleBucIdentifisertService.bucIdentifisert(
             bucIdentifisertEvent.getBucId(),
-            personFasade.hentAktoerId(bucIdentifisertEvent.getIdent())
+            personFasade.hentAktoerId(bucIdentifisertEvent.getFolkeregisterident())
         );
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sak/ArkivsakService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sak/ArkivsakService.java
@@ -8,12 +8,12 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-public class SakService {
+public class ArkivsakService {
 
     private final SakConsumer sakConsumer;
 
     @Autowired
-    public SakService(SakConsumer sakConsumer) {
+    public ArkivsakService(SakConsumer sakConsumer) {
         this.sakConsumer = sakConsumer;
     }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sak/SakService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sak/SakService.java
@@ -1,11 +1,8 @@
 package no.nav.melosys.eessi.service.sak;
 
-import java.util.Optional;
-
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.integration.sak.SakConsumer;
-import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -14,26 +11,14 @@ import org.springframework.stereotype.Service;
 public class SakService {
 
     private final SakConsumer sakConsumer;
-    private final SaksrelasjonService saksrelasjonService;
 
     @Autowired
-    public SakService(SakConsumer sakConsumer, SaksrelasjonService saksrelasjonService) {
+    public SakService(SakConsumer sakConsumer) {
         this.sakConsumer = sakConsumer;
-        this.saksrelasjonService = saksrelasjonService;
     }
 
     public Sak hentsak(Long id) {
         return sakConsumer.getSak(Long.toString(id));
     }
 
-    public Optional<Sak> finnSakForRinaSaksnummer(String rinaSaksnummer) {
-        Optional<String> saksnummer = saksrelasjonService.søkEtterSaksnummerFraRinaSaksnummer(rinaSaksnummer)
-                .map(Object::toString);
-
-        if (saksnummer.isPresent()) {
-            return Optional.of(sakConsumer.getSak(saksnummer.get()));
-        }
-
-        return Optional.empty();
-    }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonOpprettetEventListener.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonOpprettetEventListener.java
@@ -3,7 +3,7 @@ package no.nav.melosys.eessi.service.saksrelasjon;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.identifisering.BucIdentifisertService;
 import no.nav.melosys.eessi.integration.PersonFasade;
-import no.nav.melosys.eessi.service.sak.SakService;
+import no.nav.melosys.eessi.service.sak.ArkivsakService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,14 +12,14 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class SaksrelasjonOpprettetEventListener {
 
-    private final SakService sakService;
+    private final ArkivsakService arkivsakService;
     private final PersonFasade personFasade;
     private final BucIdentifisertService bucIdentifisertService;
 
-    public SaksrelasjonOpprettetEventListener(SakService sakService,
+    public SaksrelasjonOpprettetEventListener(ArkivsakService arkivsakService,
                                               PersonFasade personFasade,
                                               BucIdentifisertService bucIdentifisertService) {
-        this.sakService = sakService;
+        this.arkivsakService = arkivsakService;
         this.personFasade = personFasade;
         this.bucIdentifisertService = bucIdentifisertService;
     }
@@ -28,7 +28,7 @@ public class SaksrelasjonOpprettetEventListener {
     @TransactionalEventListener
     public void saksrelasjonOpprettet(SaksrelasjonOpprettetEvent event) {
         final var norskIdent = personFasade.hentNorskIdent(
-            sakService.hentsak(event.getArkivsakID()).getAktoerId()
+            arkivsakService.hentsak(event.getArkivsakID()).getAktoerId()
         );
 
         bucIdentifisertService.lagreIdentifisertPerson(

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonOpprettetEventListener.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonOpprettetEventListener.java
@@ -1,24 +1,39 @@
 package no.nav.melosys.eessi.service.saksrelasjon;
 
-import lombok.AllArgsConstructor;
-import no.nav.melosys.eessi.identifisering.event.BucIdentifisertEvent;
-import no.nav.melosys.eessi.integration.sak.SakConsumer;
-import org.springframework.context.ApplicationEventPublisher;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.melosys.eessi.identifisering.BucIdentifisertService;
+import no.nav.melosys.eessi.integration.PersonFasade;
+import no.nav.melosys.eessi.service.sak.SakService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
-@AllArgsConstructor
 public class SaksrelasjonOpprettetEventListener {
 
-    private final SakConsumer sakConsumer;
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final SakService sakService;
+    private final PersonFasade personFasade;
+    private final BucIdentifisertService bucIdentifisertService;
+
+    public SaksrelasjonOpprettetEventListener(SakService sakService,
+                                              PersonFasade personFasade,
+                                              BucIdentifisertService bucIdentifisertService) {
+        this.sakService = sakService;
+        this.personFasade = personFasade;
+        this.bucIdentifisertService = bucIdentifisertService;
+    }
 
     @Async
     @TransactionalEventListener
     public void saksrelasjonOpprettet(SaksrelasjonOpprettetEvent event) {
-        var sak = sakConsumer.getSak(event.getArkivsakID().toString());
-        applicationEventPublisher.publishEvent(new BucIdentifisertEvent(event.getRinaSaksnummer(), sak.getAktoerId()));
+        final var norskIdent = personFasade.hentNorskIdent(
+            sakService.hentsak(event.getArkivsakID()).getAktoerId()
+        );
+
+        bucIdentifisertService.lagreIdentifisertPerson(
+            event.getRinaSaksnummer(),
+            norskIdent
+        );
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonService.java
@@ -6,10 +6,11 @@ import java.util.Optional;
 import lombok.AllArgsConstructor;
 import no.nav.melosys.eessi.integration.eux.case_store.CaseStoreConsumer;
 import no.nav.melosys.eessi.integration.eux.case_store.CaseStoreDto;
-import no.nav.melosys.eessi.integration.sak.SakConsumer;
+import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.repository.FagsakRinasakKoblingRepository;
+import no.nav.melosys.eessi.service.sak.SakService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,12 +21,12 @@ public class SaksrelasjonService {
 
     private final FagsakRinasakKoblingRepository fagsakRinasakKoblingRepository;
     private final CaseStoreConsumer caseStoreConsumer;
-    private final SakConsumer sakConsumer;
+    private final SakService sakService;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public FagsakRinasakKobling lagreKobling(Long gsakSaksnummer, String rinaSaksnummer, BucType bucType) {
-        FagsakRinasakKobling fagsakRinasakKobling = new FagsakRinasakKobling();
+        var fagsakRinasakKobling = new FagsakRinasakKobling();
         fagsakRinasakKobling.setRinaSaksnummer(rinaSaksnummer);
         fagsakRinasakKobling.setGsakSaksnummer(gsakSaksnummer);
         fagsakRinasakKobling.setBucType(bucType);
@@ -40,17 +41,18 @@ public class SaksrelasjonService {
     }
 
     private void oppdaterEllerLagreIEuxCaseStore(Long gsakSaksnummer, String rinaSaksnummer) {
-        Optional<CaseStoreDto> caseStoreDto = caseStoreConsumer.finnVedRinaSaksnummer(rinaSaksnummer)
-                .stream().findFirst();
-        if (caseStoreDto.isPresent()) {
-            String tema = sakConsumer.getSak(gsakSaksnummer.toString()).getTema();
-            CaseStoreDto dto = caseStoreDto.get();
-            dto.setTema(tema);
-            dto.setFagsaknummer(gsakSaksnummer.toString());
-            caseStoreConsumer.lagre(dto);
-        } else {
-            caseStoreConsumer.lagre(gsakSaksnummer.toString(), rinaSaksnummer);
-        }
+        caseStoreConsumer.finnVedRinaSaksnummer(rinaSaksnummer)
+            .stream()
+            .findFirst()
+            .ifPresentOrElse(
+                dto -> {
+                    String tema = sakService.hentsak(gsakSaksnummer).getTema();
+                    dto.setTema(tema);
+                    dto.setFagsaknummer(gsakSaksnummer.toString());
+                    caseStoreConsumer.lagre(dto);
+                },
+                () -> caseStoreConsumer.lagre(gsakSaksnummer.toString(), rinaSaksnummer)
+            );
     }
 
     @Transactional
@@ -69,7 +71,6 @@ public class SaksrelasjonService {
     /**
      * Finner melosys-sak tilknyttet rina-sak lagret i egen DB
      */
-    @Transactional(readOnly = true)
     public Optional<FagsakRinasakKobling> finnVedRinaSaksnummer(String rinaSaksnummer) {
         return fagsakRinasakKoblingRepository.findByRinaSaksnummer(rinaSaksnummer);
     }
@@ -78,14 +79,13 @@ public class SaksrelasjonService {
      * Søker etter saksnummer i både egen DB og eux-case-store
      * For også å fange opp evt. lovvalgs-sed'er som er opprettet fra nEESSI
      */
-    @Transactional(readOnly = true)
     public Optional<Long> søkEtterSaksnummerFraRinaSaksnummer(String rinaSaksnummer) {
         Optional<Long> saksnummer = fagsakRinasakKoblingRepository.findByRinaSaksnummer(rinaSaksnummer)
-                .map(FagsakRinasakKobling::getGsakSaksnummer);
+            .map(FagsakRinasakKobling::getGsakSaksnummer);
 
-        if (!saksnummer.isPresent()) {
+        if (saksnummer.isEmpty()) {
             saksnummer = caseStoreConsumer.finnVedRinaSaksnummer(rinaSaksnummer).stream()
-                    .findFirst().map(CaseStoreDto::getFagsaknummer).map(Long::parseLong);
+                .findFirst().map(CaseStoreDto::getFagsaknummer).map(Long::parseLong);
         }
 
         return saksnummer;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonService.java
@@ -10,7 +10,7 @@ import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.repository.FagsakRinasakKoblingRepository;
-import no.nav.melosys.eessi.service.sak.SakService;
+import no.nav.melosys.eessi.service.sak.ArkivsakService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +21,7 @@ public class SaksrelasjonService {
 
     private final FagsakRinasakKoblingRepository fagsakRinasakKoblingRepository;
     private final CaseStoreConsumer caseStoreConsumer;
-    private final SakService sakService;
+    private final ArkivsakService arkivsakService;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
@@ -46,7 +46,7 @@ public class SaksrelasjonService {
             .findFirst()
             .ifPresentOrElse(
                 dto -> {
-                    String tema = sakService.hentsak(gsakSaksnummer).getTema();
+                    String tema = arkivsakService.hentsak(gsakSaksnummer).getTema();
                     dto.setTema(tema);
                     dto.setFagsaknummer(gsakSaksnummer.toString());
                     caseStoreConsumer.lagre(dto);
@@ -99,6 +99,6 @@ public class SaksrelasjonService {
     public Optional<Sak> finnArkivsakForRinaSaksnummer(String rinaSaksnummer) {
         return finnVedRinaSaksnummer(rinaSaksnummer)
             .map(FagsakRinasakKobling::getGsakSaksnummer)
-            .map(sakService::hentsak);
+            .map(arkivsakService::hentsak);
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonService.java
@@ -90,4 +90,15 @@ public class SaksrelasjonService {
 
         return saksnummer;
     }
+
+    public Optional<String> finnAktørIDTilhørendeRinasak(String rinaSaksnummer) {
+        return finnArkivsakForRinaSaksnummer(rinaSaksnummer)
+            .map(Sak::getAktoerId);
+    }
+
+    public Optional<Sak> finnArkivsakForRinaSaksnummer(String rinaSaksnummer) {
+        return finnVedRinaSaksnummer(rinaSaksnummer)
+            .map(FagsakRinasakKobling::getGsakSaksnummer)
+            .map(sakService::hentsak);
+    }
 }

--- a/melosys-eessi-app/src/main/resources/db/migration/V2_3__buc_identifisert.sql
+++ b/melosys-eessi-app/src/main/resources/db/migration/V2_3__buc_identifisert.sql
@@ -2,7 +2,7 @@ CREATE TABLE BUC_IDENTIFISERT
 (
     id serial NOT NULL PRIMARY KEY,
     rina_saksnummer VARCHAR(20) NOT NULL,
-    ident VARCHAR(20) NOT NULL
+    folkeregisterident VARCHAR(20) NOT NULL
 );
 
 CREATE INDEX idx_buc_identifisert_rina_saksnummer ON BUC_IDENTIFISERT(rina_saksnummer);

--- a/melosys-eessi-app/src/main/resources/db/migration/V2_3__buc_identifisert.sql
+++ b/melosys-eessi-app/src/main/resources/db/migration/V2_3__buc_identifisert.sql
@@ -1,0 +1,8 @@
+CREATE TABLE BUC_IDENTIFISERT
+(
+    id serial NOT NULL PRIMARY KEY,
+    rina_saksnummer VARCHAR(20) NOT NULL,
+    ident VARCHAR(20) NOT NULL
+);
+
+CREATE INDEX idx_buc_identifisert_rina_saksnummer ON BUC_IDENTIFISERT(rina_saksnummer);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/BucIdentifisertServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/BucIdentifisertServiceTest.java
@@ -1,0 +1,69 @@
+package no.nav.melosys.eessi.identifisering;
+
+import java.util.Optional;
+
+import no.nav.melosys.eessi.integration.PersonFasade;
+import no.nav.melosys.eessi.integration.sak.Sak;
+import no.nav.melosys.eessi.models.BucIdentifisert;
+import no.nav.melosys.eessi.repository.BucIdentifisertRepository;
+import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BucIdentifisertServiceTest {
+
+    @Mock
+    private BucIdentifisertRepository bucIdentifisertRepository;
+    @Mock
+    private SaksrelasjonService saksrelasjonService;
+    @Mock
+    private PersonFasade personFasade;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    private BucIdentifisertService bucIdentifisertService;
+
+    private final String rinaSaksnummer = "1111";
+    private final String aktørID = "123123123";
+    private final String norskIdent = "321321321";
+    private final Sak arkivsak = new Sak();
+
+    @BeforeEach
+    void setup() {
+        arkivsak.setAktoerId(aktørID);
+        bucIdentifisertService = new BucIdentifisertService(
+            bucIdentifisertRepository, saksrelasjonService, personFasade, applicationEventPublisher
+        );
+    }
+
+    @Test
+    void finnIdentifisertPerson_personIkkeIdentifisert_tomReturverdi() {
+        assertThat(bucIdentifisertService.finnIdentifisertPerson(rinaSaksnummer)).isEmpty();
+    }
+
+    @Test
+    void finnIdentifisertPerson_saksrelasjonFinnes_ident() {
+        when(saksrelasjonService.finnAktørIDTilhørendeRinasak(rinaSaksnummer)).thenReturn(Optional.of(aktørID));
+        when(personFasade.hentNorskIdent(aktørID)).thenReturn(norskIdent);
+
+        assertThat(bucIdentifisertService.finnIdentifisertPerson(rinaSaksnummer)).contains(norskIdent);
+        verify(bucIdentifisertRepository, never()).findByRinaSaksnummer(anyString());
+    }
+
+    @Test
+    void finnIdentifisertPerson_bucIdentifisert_ident() {
+        when(bucIdentifisertRepository.findByRinaSaksnummer(rinaSaksnummer))
+            .thenReturn(Optional.of(new BucIdentifisert(1L, rinaSaksnummer, norskIdent)));
+
+        assertThat(bucIdentifisertService.finnIdentifisertPerson(rinaSaksnummer)).contains(norskIdent);
+    }
+}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/SedIdentifiseringServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/SedIdentifiseringServiceTest.java
@@ -3,9 +3,6 @@ package no.nav.melosys.eessi.identifisering;
 import java.util.List;
 import java.util.Optional;
 
-import no.nav.melosys.eessi.integration.PersonFasade;
-import no.nav.melosys.eessi.integration.sak.Sak;
-import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.nav.Bruker;
@@ -13,8 +10,6 @@ import no.nav.melosys.eessi.models.sed.nav.Nav;
 import no.nav.melosys.eessi.models.sed.nav.Person;
 import no.nav.melosys.eessi.models.sed.nav.Pin;
 import no.nav.melosys.eessi.service.personsok.PersonsokKriterier;
-import no.nav.melosys.eessi.service.sak.SakService;
-import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,7 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,36 +30,22 @@ class SedIdentifiseringServiceTest {
     @Mock
     private PersonSok personSok;
     @Mock
-    private SaksrelasjonService saksrelasjonService;
-    @Mock
-    private SakService sakService;
-    @Mock
-    private PersonFasade personFasade;
-    @Mock
     private PersonSokMetrikker personSokMetrikker;
+    @Mock
+    private BucIdentifisertService bucIdentifisertService;
 
     private SedIdentifiseringService sedIdentifiseringService;
 
     @BeforeEach
     public void setup() {
-        sedIdentifiseringService = new SedIdentifiseringService(
-                personSok, saksrelasjonService, sakService, personFasade, personSokMetrikker
-        );
+        sedIdentifiseringService = new SedIdentifiseringService(personSok, personSokMetrikker, bucIdentifisertService);
     }
 
     @Test
     void identifiserPerson_sakEksisterer_hentPersonFraSak() {
-        Sak sak = new Sak();
-        sak.setAktoerId("32132132");
-
-        FagsakRinasakKobling fagsakRinasakKobling = new FagsakRinasakKobling();
-        fagsakRinasakKobling.setGsakSaksnummer(123L);
-
-        when(personFasade.hentNorskIdent(anyString())).thenReturn(norskIdent);
-        when(sakService.hentsak(anyLong())).thenReturn(sak);
-        when(saksrelasjonService.finnVedRinaSaksnummer(anyString())).thenReturn(Optional.of(fagsakRinasakKobling));
-
-        Optional<String> res = sedIdentifiseringService.identifiserPerson("123", lagSED());
+        final var rinaSaksnummer = "123321";
+        when(bucIdentifisertService.finnIdentifisertPerson(rinaSaksnummer)).thenReturn(Optional.of(norskIdent));
+        Optional<String> res = sedIdentifiseringService.identifiserPerson(rinaSaksnummer, lagSED());
         assertThat(res).contains(norskIdent);
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/behandling/SedMottakServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/behandling/SedMottakServiceTest.java
@@ -5,9 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import no.nav.melosys.eessi.identifisering.BucIdentifisertService;
 import no.nav.melosys.eessi.identifisering.PersonIdentifisering;
-import no.nav.melosys.eessi.identifisering.event.BucIdentifisertEvent;
-import no.nav.melosys.eessi.integration.PersonFasade;
 import no.nav.melosys.eessi.integration.journalpostapi.SedAlleredeJournalførtException;
 import no.nav.melosys.eessi.integration.oppgave.HentOppgaveDto;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -38,27 +36,18 @@ class SedMottakServiceTest {
 
     @Mock
     private OpprettInngaaendeJournalpostService opprettInngaaendeJournalpostService;
-
     @Mock
     private EuxService euxService;
-
     @Mock
     private PersonIdentifisering personIdentifisering;
-
     @Mock
     private OppgaveService oppgaveService;
-
-    @Mock
-    private ApplicationEventPublisher applicationEventPublisher;
-
     @Mock
     private SedMottattHendelseRepository sedMottattHendelseRepository;
-
     @Mock
     private BucIdentifiseringOppgRepository bucIdentifiseringOppgRepository;
-
     @Mock
-    private PersonFasade personFasade;
+    private BucIdentifisertService bucIdentifisertService;
 
     private SedMottakService sedMottakService;
 
@@ -69,8 +58,8 @@ class SedMottakServiceTest {
     public void setup() throws Exception {
         sedMottakService = new SedMottakService(
                 euxService, personIdentifisering, opprettInngaaendeJournalpostService,
-                oppgaveService, applicationEventPublisher, sedMottattHendelseRepository,
-                bucIdentifiseringOppgRepository, personFasade
+                oppgaveService, sedMottattHendelseRepository,
+                bucIdentifiseringOppgRepository, bucIdentifisertService
         );
 
         when(opprettInngaaendeJournalpostService.arkiverInngaaendeSedUtenBruker(any(), any(), any()))
@@ -95,7 +84,7 @@ class SedMottakServiceTest {
         verify(opprettInngaaendeJournalpostService).arkiverInngaaendeSedUtenBruker(any(), any(), any());
         verify(oppgaveService).opprettOppgaveTilIdOgFordeling(anyString(), anyString(), anyString());
         verify(sedMottattHendelseRepository, times(2)).save(any());
-        verify(applicationEventPublisher, never()).publishEvent(BucIdentifisertEvent.class);
+        verify(bucIdentifisertService, never()).lagreIdentifisertPerson(anyString(), anyString());
     }
 
     @Test
@@ -110,7 +99,7 @@ class SedMottakServiceTest {
         verify(opprettInngaaendeJournalpostService).arkiverInngaaendeSedUtenBruker(any(), any(), any());
         verify(oppgaveService, never()).opprettOppgaveTilIdOgFordeling(anyString(), anyString(), anyString());
         verify(sedMottattHendelseRepository, times(2)).save(any());
-        verify(applicationEventPublisher).publishEvent(any(BucIdentifisertEvent.class));
+        verify(bucIdentifisertService).lagreIdentifisertPerson(sedHendelse.getRinaSakId(), IDENT);
     }
 
     @Test
@@ -128,7 +117,7 @@ class SedMottakServiceTest {
 
         verify(opprettInngaaendeJournalpostService).arkiverInngaaendeSedUtenBruker(any(), any(), any());
         verify(oppgaveService, never()).opprettOppgaveTilIdOgFordeling(anyString(), anyString(), anyString());
-        verify(applicationEventPublisher, never()).publishEvent(any(BucIdentifisertEvent.class));
+        verify(bucIdentifisertService, never()).lagreIdentifisertPerson(anyString(), anyString());
     }
 
     @Test

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/OpprettUtgaaendeJournalpostServiceTest.java
@@ -13,7 +13,7 @@ import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
 import no.nav.melosys.eessi.service.eux.EuxService;
 import no.nav.melosys.eessi.service.oppgave.OppgaveService;
-import no.nav.melosys.eessi.service.sak.SakService;
+import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,7 +32,7 @@ class OpprettUtgaaendeJournalpostServiceTest {
     private static final String JOURNALPOST_ID = "123";
 
     @Mock
-    private SakService sakService;
+    private SaksrelasjonService saksrelasjonService;
     @Mock
     private JournalpostService journalpostService;
     @Mock
@@ -50,12 +50,12 @@ class OpprettUtgaaendeJournalpostServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         opprettUtgaaendeJournalpostService = new OpprettUtgaaendeJournalpostService(
-                sakService, journalpostService, euxService, personFasade, oppgaveService);
+            saksrelasjonService, journalpostService, euxService, personFasade, oppgaveService);
 
         when(euxService.hentSedMedVedlegg(anyString(), anyString())).thenReturn(sedMedVedlegg(new byte[0]));
 
         Sak sak = enhancedRandom.nextObject(Sak.class);
-        when(sakService.finnSakForRinaSaksnummer(anyString())).thenReturn(Optional.of(sak));
+        when(saksrelasjonService.finnArkivsakForRinaSaksnummer(anyString())).thenReturn(Optional.of(sak));
 
         sedSendt = enhancedRandom.nextObject(SedHendelse.class);
     }
@@ -80,7 +80,7 @@ class OpprettUtgaaendeJournalpostServiceTest {
 
         String result = opprettUtgaaendeJournalpostService.arkiverUtgaaendeSed(sedSendt);
 
-        verify(sakService).finnSakForRinaSaksnummer(anyString());
+        verify(saksrelasjonService).finnArkivsakForRinaSaksnummer(anyString());
         verify(journalpostService).opprettUtgaaendeJournalpost(any(), any(), any(), any());
         verify(oppgaveService).opprettUtgåendeJfrOppgave(anyString(), any(), anyString(), anyString());
 
@@ -92,12 +92,12 @@ class OpprettUtgaaendeJournalpostServiceTest {
         OpprettJournalpostResponse response = new OpprettJournalpostResponse(JOURNALPOST_ID, new ArrayList<>(), "ENDELIG", null);
         when(journalpostService.opprettUtgaaendeJournalpost(any(SedHendelse.class), any(), any(), any())).thenReturn(response);
         when(euxService.hentRinaUrl(anyString())).thenReturn("https://test.local");
-        when(sakService.finnSakForRinaSaksnummer(anyString())).thenReturn(Optional.empty());
+        when(saksrelasjonService.finnArkivsakForRinaSaksnummer(anyString())).thenReturn(Optional.empty());
         when(personFasade.hentAktoerId(anyString())).thenReturn("12345");
 
         String journalpostId = opprettUtgaaendeJournalpostService.arkiverUtgaaendeSed(sedSendt);
 
-        verify(sakService).finnSakForRinaSaksnummer(anyString());
+        verify(saksrelasjonService).finnArkivsakForRinaSaksnummer(anyString());
         verify(journalpostService).opprettUtgaaendeJournalpost(any(), any(), any(), any());
         verify(oppgaveService).opprettUtgåendeJfrOppgave(anyString(), any(), anyString(), anyString());
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sak/ArkivsakServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sak/ArkivsakServiceTest.java
@@ -13,22 +13,22 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class SakServiceTest {
+class ArkivsakServiceTest {
 
     @Mock
     private SakConsumer sakConsumer;
 
-    private SakService sakService;
+    private ArkivsakService arkivsakService;
 
     @BeforeEach
     public void setup() throws Exception {
-        sakService = new SakService(sakConsumer);
+        arkivsakService = new ArkivsakService(sakConsumer);
         when(sakConsumer.getSak(anyString())).thenReturn(new Sak());
     }
 
     @Test
     void hentSak_forventSak() {
-        Sak sak = sakService.hentsak(1L);
+        Sak sak = arkivsakService.hentsak(1L);
         assertThat(sak).isNotNull();
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sak/SakServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sak/SakServiceTest.java
@@ -1,11 +1,7 @@
 package no.nav.melosys.eessi.service.sak;
 
-import java.util.Optional;
-
 import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.integration.sak.SakConsumer;
-import no.nav.melosys.eessi.models.FagsakRinasakKobling;
-import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,14 +17,12 @@ class SakServiceTest {
 
     @Mock
     private SakConsumer sakConsumer;
-    @Mock
-    private SaksrelasjonService saksrelasjonService;
 
     private SakService sakService;
 
     @BeforeEach
     public void setup() throws Exception {
-        sakService = new SakService(sakConsumer, saksrelasjonService);
+        sakService = new SakService(sakConsumer);
         when(sakConsumer.getSak(anyString())).thenReturn(new Sak());
     }
 
@@ -36,19 +30,5 @@ class SakServiceTest {
     void hentSak_forventSak() {
         Sak sak = sakService.hentsak(1L);
         assertThat(sak).isNotNull();
-    }
-
-    @Test
-    void finnSakForRinaSaksnummer_saksrelasjonLagret_forventSak() {
-        FagsakRinasakKobling fagsakRinasakKobling = new FagsakRinasakKobling();
-        fagsakRinasakKobling.setGsakSaksnummer(123L);
-        when(saksrelasjonService.søkEtterSaksnummerFraRinaSaksnummer(anyString())).thenReturn(Optional.of(123L));
-        assertThat(sakService.finnSakForRinaSaksnummer("123")).isPresent();
-    }
-
-    @Test
-    void finnSakForRinaSaksnummer_saksrelasjonLagretHosEux_forventSak() {
-        when(saksrelasjonService.søkEtterSaksnummerFraRinaSaksnummer(anyString())).thenReturn(Optional.of(123L));
-        assertThat(sakService.finnSakForRinaSaksnummer("123321")).isPresent();
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonServiceTest.java
@@ -9,7 +9,7 @@ import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.repository.FagsakRinasakKoblingRepository;
-import no.nav.melosys.eessi.service.sak.SakService;
+import no.nav.melosys.eessi.service.sak.ArkivsakService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +30,7 @@ class SaksrelasjonServiceTest {
     @Mock
     private CaseStoreConsumer caseStoreConsumer;
     @Mock
-    private SakService sakService;
+    private ArkivsakService arkivsakService;
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
@@ -38,7 +38,7 @@ class SaksrelasjonServiceTest {
 
     @BeforeEach
     public void setup() {
-        saksrelasjonService = new SaksrelasjonService(fagsakRinasakKoblingRepository, caseStoreConsumer, sakService, applicationEventPublisher);
+        saksrelasjonService = new SaksrelasjonService(fagsakRinasakKoblingRepository, caseStoreConsumer, arkivsakService, applicationEventPublisher);
     }
 
     private final String RINA_ID = "321";
@@ -59,7 +59,7 @@ class SaksrelasjonServiceTest {
     @Test
     void lagreKobling_ikkeLovvalgBucSakEksistererICaseStore_oppdaterCaseStore() {
         CaseStoreDto caseStoreDto = new CaseStoreDto(1L, "bucid", "saksnummer", "rinasaksnummer", "journalpostid", "tema");
-        when(sakService.hentsak(anyLong())).thenReturn(new Sak());
+        when(arkivsakService.hentsak(anyLong())).thenReturn(new Sak());
         when(caseStoreConsumer.finnVedRinaSaksnummer(anyString())).thenReturn(Collections.singletonList(caseStoreDto));
         saksrelasjonService.lagreKobling(123L, "321", BucType.H_BUC_01);
         verify(caseStoreConsumer).lagre(any(CaseStoreDto.class));
@@ -105,7 +105,7 @@ class SaksrelasjonServiceTest {
 
         final var arkivsak = new Sak();
         arkivsak.setId("3333333");
-        when(sakService.hentsak(fagsakRinasakKobling.getGsakSaksnummer())).thenReturn(arkivsak);
+        when(arkivsakService.hentsak(fagsakRinasakKobling.getGsakSaksnummer())).thenReturn(arkivsak);
 
         assertThat(saksrelasjonService.finnArkivsakForRinaSaksnummer("123")).contains(arkivsak);
     }
@@ -124,7 +124,7 @@ class SaksrelasjonServiceTest {
 
         final var arkivsak = new Sak();
         arkivsak.setAktoerId(aktørID);
-        when(sakService.hentsak(fagsakRinasakKobling.getGsakSaksnummer())).thenReturn(arkivsak);
+        when(arkivsakService.hentsak(fagsakRinasakKobling.getGsakSaksnummer())).thenReturn(arkivsak);
 
 
         assertThat(saksrelasjonService.finnAktørIDTilhørendeRinasak("123")).contains(aktørID);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonServiceTest.java
@@ -6,10 +6,10 @@ import java.util.Optional;
 import no.nav.melosys.eessi.integration.eux.case_store.CaseStoreConsumer;
 import no.nav.melosys.eessi.integration.eux.case_store.CaseStoreDto;
 import no.nav.melosys.eessi.integration.sak.Sak;
-import no.nav.melosys.eessi.integration.sak.SakConsumer;
 import no.nav.melosys.eessi.models.BucType;
 import no.nav.melosys.eessi.models.FagsakRinasakKobling;
 import no.nav.melosys.eessi.repository.FagsakRinasakKoblingRepository;
+import no.nav.melosys.eessi.service.sak.SakService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,8 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,7 +30,7 @@ class SaksrelasjonServiceTest {
     @Mock
     private CaseStoreConsumer caseStoreConsumer;
     @Mock
-    private SakConsumer sakConsumer;
+    private SakService sakService;
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
@@ -39,7 +38,7 @@ class SaksrelasjonServiceTest {
 
     @BeforeEach
     public void setup() {
-        saksrelasjonService = new SaksrelasjonService(fagsakRinasakKoblingRepository, caseStoreConsumer, sakConsumer, applicationEventPublisher);
+        saksrelasjonService = new SaksrelasjonService(fagsakRinasakKoblingRepository, caseStoreConsumer, sakService, applicationEventPublisher);
     }
 
     private final String RINA_ID = "321";
@@ -60,7 +59,7 @@ class SaksrelasjonServiceTest {
     @Test
     void lagreKobling_ikkeLovvalgBucSakEksistererICaseStore_oppdaterCaseStore() {
         CaseStoreDto caseStoreDto = new CaseStoreDto(1L, "bucid", "saksnummer", "rinasaksnummer", "journalpostid", "tema");
-        when(sakConsumer.getSak(anyString())).thenReturn(new Sak());
+        when(sakService.hentsak(anyLong())).thenReturn(new Sak());
         when(caseStoreConsumer.finnVedRinaSaksnummer(anyString())).thenReturn(Collections.singletonList(caseStoreDto));
         saksrelasjonService.lagreKobling(123L, "321", BucType.H_BUC_01);
         verify(caseStoreConsumer).lagre(any(CaseStoreDto.class));
@@ -91,5 +90,43 @@ class SaksrelasjonServiceTest {
                 .thenReturn(Collections.singletonList(new CaseStoreDto("123", rinaSaksnummer)));
         Optional<Long> saksnummer = saksrelasjonService.søkEtterSaksnummerFraRinaSaksnummer(rinaSaksnummer);
         assertThat(saksnummer).contains(123L);
+    }
+
+    @Test
+    void finnArkivsakForRinaSaksnummer_finnesIkke_tomReturverdi() {
+        assertThat(saksrelasjonService.finnAktørIDTilhørendeRinasak("123")).isEmpty();
+    }
+
+    @Test
+    void finnArkivsakForRinaSaksnummer_saksrelasjonFinnes_returnererArkivsak() {
+        final var fagsakRinasakKobling = new FagsakRinasakKobling();
+        fagsakRinasakKobling.setGsakSaksnummer(321L);
+        when(fagsakRinasakKoblingRepository.findByRinaSaksnummer("123")).thenReturn(Optional.of(fagsakRinasakKobling));
+
+        final var arkivsak = new Sak();
+        arkivsak.setId("3333333");
+        when(sakService.hentsak(fagsakRinasakKobling.getGsakSaksnummer())).thenReturn(arkivsak);
+
+        assertThat(saksrelasjonService.finnArkivsakForRinaSaksnummer("123")).contains(arkivsak);
+    }
+
+    @Test
+    void finnAktørIDTilhørendeRinasak_finnesIkke_tomReturverdi() {
+        assertThat(saksrelasjonService.finnAktørIDTilhørendeRinasak("123")).isEmpty();
+    }
+
+    @Test
+    void finnAktørIDTilhørendeRinasak_saksrelasjonFinnes_returnererAktørID() {
+        final var aktørID = "1111";
+        final var fagsakRinasakKobling = new FagsakRinasakKobling();
+        fagsakRinasakKobling.setGsakSaksnummer(321L);
+        when(fagsakRinasakKoblingRepository.findByRinaSaksnummer("123")).thenReturn(Optional.of(fagsakRinasakKobling));
+
+        final var arkivsak = new Sak();
+        arkivsak.setAktoerId(aktørID);
+        when(sakService.hentsak(fagsakRinasakKobling.getGsakSaksnummer())).thenReturn(arkivsak);
+
+
+        assertThat(saksrelasjonService.finnAktørIDTilhørendeRinasak("123")).contains(aktørID);
     }
 }

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestBase.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestBase.java
@@ -117,19 +117,25 @@ public abstract class ComponentTestBase {
         when(dokumenttypeInfoConsumer.hentDokumenttypeInfo(anyString())).thenReturn(mockData.dokumentTypeInfoDto());
     }
 
-    @SneakyThrows
     protected void mockPerson(String ident, String aktørID) {
         mockPerson(ident, aktørID, FØDSELSDATO, STATSBORGERSKAP);
     }
 
     protected void mockPerson(String ident, String aktørID, LocalDate fødselsdato, String statsborgerskap) {
-        var pdlIdentListe = mockData.lagPDLIdentListe(ident, aktørID);
-        when(pdlConsumer.hentIdenter(ident)).thenReturn(pdlIdentListe);
-        when(pdlConsumer.hentIdenter(aktørID)).thenReturn(pdlIdentListe);
+        mockHentPerson(ident, aktørID, fødselsdato, statsborgerskap);
+        mockHentIdenter(ident, aktørID);
+    }
 
+    private void mockHentPerson(String ident, String aktørID, LocalDate fødselsdato, String statsborgerskap) {
         var pdlPerson = mockData.pdlPerson(fødselsdato, statsborgerskap);
         when(pdlConsumer.hentPerson(ident)).thenReturn(pdlPerson);
         when(pdlConsumer.hentPerson(aktørID)).thenReturn(pdlPerson);
+    }
+
+    protected void mockHentIdenter(String ident, String aktørID) {
+        var pdlIdentListe = mockData.lagPDLIdentListe(ident, aktørID);
+        when(pdlConsumer.hentIdenter(ident)).thenReturn(pdlIdentListe);
+        when(pdlConsumer.hentIdenter(aktørID)).thenReturn(pdlIdentListe);
     }
 
     List<MelosysEessiMelding> hentMelosysEessiRecords() {

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedMottakTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedMottakTestIT.java
@@ -129,6 +129,7 @@ class SedMottakTestIT extends ComponentTestBase {
         when(euxConsumer.hentSed(anyString(), anyString())).thenReturn(mockData.sed(FØDSELSDATO, STATSBORGERSKAP, null));
         when(pdlConsumer.søkPerson(any())).thenReturn(new PDLSokPerson());
         when(oppgaveConsumer.opprettOppgave(any())).thenReturn(new HentOppgaveDto(oppgaveID, "AAPEN"));
+        mockHentIdenter(FNR, AKTOER_ID);
 
         kafkaTestConsumer.reset(1);
         kafkaTemplate.send(lagSedMottattRecord(mockData.sedHendelse(rinaSaksnummer, sedID, null))).get();
@@ -151,7 +152,6 @@ class SedMottakTestIT extends ComponentTestBase {
     @Test
     void sedMottattIkkeIdentifisert_oppgaveBlirIdentifisertOgMarkertSomFeilIdentifisert_flyttesTilIdOgFordeling() throws Exception {
         final var sedID = UUID.randomUUID().toString();
-        final var sedID2 = UUID.randomUUID().toString();
         final var oppgaveID = Integer.toString(new Random().nextInt(100000));
         final var oppgaveDto = new HentOppgaveDto(oppgaveID, "AAPEN");
         oppgaveDto.setStatus("OPPRETTET");


### PR DESCRIPTION
Lagrer ident identifisert for BUC sammen med saksnummeret. Dette i hovedsak for å unngå et race-condition hvor flere identifiseringsevent behandles samtidig, men også for å gi melosys-eessi mer eierskap til selve identifiseringen av BUCen, hvor den når har lent seg på å hente ut dette fra arkivsaken.

Også litt småoppussing rundt omkring.