### PR TITLE
Aldri hent sed dersom det er av typen X100, den er bare printbar og i…

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/SedType.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/SedType.java
@@ -19,6 +19,7 @@ public enum SedType {
     X012,
     X013,
     X050,
+    X100,
 
     A001,
     A002,

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
@@ -117,6 +117,7 @@ public class BUC {
         return documents.stream()
             .filter(Document::erInngående)
             .filter(Document::erOpprettet)
+            .filter(Document::erIkkeX100)
             .min(Comparator.comparing(Document::getCreationDate));
     }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/Document.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/Document.java
@@ -39,6 +39,10 @@ public class Document {
         return SedType.X001.name().equals(type);
     }
 
+    public boolean erIkkeX100() {
+        return !SedType.X100.name().equals(type);
+    }
+
     public boolean erLovvalgSED() {
         return SedType.erLovvalgSed(type);
     }


### PR DESCRIPTION
Aldri hent sed dersom det er av typen X100, den er bare printbar og ikke lesbar. Mulig dette løser alle feilmeldingene med identifiseringsprossessen.