### PR TITLE
NO_JIRA-EUX_Rina_nede_workaround

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
@@ -29,7 +29,7 @@ public class IdentifiseringKontrollService {
         Optional<BUC> buc = euxService.finnBUC(rinaSaksnummer);
 
         if (buc.isEmpty()) {
-            return new IdentifiseringsKontrollResultat(Collections.emptyList());
+            return new IdentifiseringsKontrollResultat(integrasjonsKontrollRina());
         }
 
         var dokumentID = buc.get().finnFørstMottatteSed()
@@ -65,6 +65,12 @@ public class IdentifiseringKontrollService {
         }
 
         begrunnelser.forEach(personSokMetrikker::counter);
+        return begrunnelser;
+    }
+
+    private Collection<IdentifiseringsKontrollBegrunnelse> integrasjonsKontrollRina() {
+        List<IdentifiseringsKontrollBegrunnelse> begrunnelser = new ArrayList<>();
+        begrunnelser.add(IdentifiseringsKontrollBegrunnelse.EUX_RINA);
         return begrunnelser;
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
@@ -1,11 +1,9 @@
 package no.nav.melosys.eessi.identifisering;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 import no.nav.melosys.eessi.integration.PersonFasade;
+import no.nav.melosys.eessi.models.buc.BUC;
 import no.nav.melosys.eessi.models.person.PersonModell;
 import no.nav.melosys.eessi.models.person.UtenlandskId;
 import no.nav.melosys.eessi.models.sed.nav.Person;
@@ -28,8 +26,13 @@ public class IdentifiseringKontrollService {
     }
 
     public IdentifiseringsKontrollResultat kontrollerIdentifisertPerson(String aktørID, String rinaSaksnummer) {
-        var buc = euxService.hentBuc(rinaSaksnummer);
-        var dokumentID = buc.finnFørstMottatteSed()
+        Optional<BUC> buc = euxService.finnBUC(rinaSaksnummer);
+
+        if (buc.isEmpty()) {
+            return new IdentifiseringsKontrollResultat(Collections.emptyList());
+        }
+
+        var dokumentID = buc.get().finnFørstMottatteSed()
             .orElseThrow(() -> new NoSuchElementException("Finner ikke første mottatte SED"))
             .getId();
 
@@ -39,7 +42,7 @@ public class IdentifiseringKontrollService {
         var identifisertPerson = personFasade.hentPerson(aktørID);
 
 
-        return new IdentifiseringsKontrollResultat(kontrollerIdentifisering(identifisertPerson, sedPerson, buc.hentAvsenderLand()));
+        return new IdentifiseringsKontrollResultat(kontrollerIdentifisering(identifisertPerson, sedPerson, buc.get().hentAvsenderLand()));
     }
 
     private Collection<IdentifiseringsKontrollBegrunnelse> kontrollerIdentifisering(PersonModell identifisertPerson, Person sedPerson, String avsenderLand) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringsKontrollBegrunnelse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringsKontrollBegrunnelse.java
@@ -4,7 +4,8 @@ public enum IdentifiseringsKontrollBegrunnelse {
     FØDSELSDATO("fødselsdato"),
     STATSBORGERSKAP("statsborgerskap"),
     KJØNN("kjønn"),
-    UTENLANDSK_ID("utenlandsk-id");
+    UTENLANDSK_ID("utenlandsk-id"),
+    EUX_RINA("Rina Integrasjon");
 
     private final String begrunnelse;
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import no.nav.melosys.eessi.integration.PersonFasade;
@@ -74,7 +75,7 @@ class IdentifiseringKontrollServiceTest {
         sed.getNav().getBruker().setPerson(sedPerson);
         sed.setSedType(SedType.A009.name());
 
-        when(euxService.hentBuc(rinaSaksnummer)).thenReturn(buc);
+        when(euxService.finnBUC(rinaSaksnummer)).thenReturn(Optional.of(buc));
         when(euxService.hentSed(rinaSaksnummer, dokumentId)).thenReturn(sed);
 
         personBuilder


### PR DESCRIPTION
Bytter hentBuc med FinnBuc som henter buc dersom det er mulig, deretter kaster vi ikke exception og vi flytter bare oppgave tilbake til ID og Fordeling