### PR TITLE
No jira refaktor oppgave endret consumer

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
@@ -48,13 +48,17 @@ public class OppgaveEndretConsumer {
     private boolean erSisteVersjonAvOppgaveMedIdentifisering(OppgaveEndretHendelse oppgaveEndretHendelse) {
         final var oppgaveId = oppgaveEndretHendelse.getId().toString();
         if (!erIdentifiseringsOppgave(oppgaveEndretHendelse)) {
-            log.info("Kan ikke behandle oppgave endret {}", oppgaveId);
             return false;
         }
 
         HentOppgaveDto oppgaveDto = oppgaveService.hentOppgave(oppgaveId);
-        if (!oppgaveEndretHendelse.harSammeVersjon(oppgaveDto.getVersjon()) || !oppgaveDto.erÅpen()) {
-            log.info("Kan ikke behandle oppgave endret {}, versjonskonflikt eller er ikke åpen opppgave", oppgaveId);
+        if (!oppgaveEndretHendelse.harSammeVersjon(oppgaveDto.getVersjon())) {
+            log.info("Kan ikke behandle oppgave endret {}, versjonskonflikt mellom kafkamelding (versjon {}) og oppgave (versjon {}) ", oppgaveId, oppgaveEndretHendelse.getVersjon(),oppgaveDto.getVersjon());
+            return false;
+        }
+
+        if (!oppgaveDto.erÅpen()) {
+            log.info("Kan ikke behandle oppgave endret {}, oppgave er ikke åpen opppgave", oppgaveId);
             return false;
         }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
@@ -35,7 +35,7 @@ public class OppgaveEndretConsumer {
         final var oppgave = consumerRecord.value();
         log.debug("Oppgave endret: {}", oppgave);
 
-        if (erSisteVersjonAvOppgaveMedIdentifisering(oppgave)) {
+        if (erValidertIdentifiseringsoppgave(oppgave)) {
             log.info("Oppgave {} markert som identifisert av ID og Fordeling. Søker etter tilknyttet RINA-sak", oppgave.getId());
             bucIdentifiseringOppgRepository.findByOppgaveId(oppgave.getId().toString())
                 .ifPresentOrElse(
@@ -45,12 +45,12 @@ public class OppgaveEndretConsumer {
         }
     }
 
-    private boolean erSisteVersjonAvOppgaveMedIdentifisering(OppgaveEndretHendelse oppgaveEndretHendelse) {
-        final var oppgaveId = oppgaveEndretHendelse.getId().toString();
-        if (!erIdentifiseringsOppgave(oppgaveEndretHendelse)) {
-            return false;
-        }
+    private boolean erValidertIdentifiseringsoppgave(OppgaveEndretHendelse oppgaveEndretHendelse) {
+        return erIdentifiseringsOppgave(oppgaveEndretHendelse) && validerOppgaveStatusOgVersjon(oppgaveEndretHendelse);
+    }
 
+    private boolean validerOppgaveStatusOgVersjon(OppgaveEndretHendelse oppgaveEndretHendelse) {
+        final var oppgaveId = oppgaveEndretHendelse.getId().toString();
         HentOppgaveDto oppgaveDto = oppgaveService.hentOppgave(oppgaveId);
         if (!oppgaveEndretHendelse.harSammeVersjon(oppgaveDto.getVersjon())) {
             log.info("Kan ikke behandle oppgave endret {}, versjonskonflikt mellom kafkamelding (versjon {}) og oppgave (versjon {}) ", oppgaveId, oppgaveEndretHendelse.getVersjon(),oppgaveDto.getVersjon());

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/oppgave/OppgaveConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/oppgave/OppgaveConsumer.java
@@ -23,7 +23,7 @@ public class OppgaveConsumer implements RestConsumer, UUIDGenerator {
 
     public HentOppgaveDto hentOppgave(String oppgaveID) {
         var correlationID = generateUUID();
-        log.info("hentOppgave, id: {}, correlationID: {}", oppgaveID, correlationID);
+        log.debug("hentOppgave, id: {}, correlationID: {}", oppgaveID, correlationID);
         return webClient.get()
                 .uri("/oppgaver/{oppgaveID}", oppgaveID)
                 .header(X_CORRELATION_ID, correlationID)


### PR DESCRIPTION
Fjerner loggnivå info på hent oppgave slik at vi ikke spammer med logging og refaktorering av logikk i identifiseringsfilter