### PR TITLE
Melosys 4877 endring sed inn tilpassing av automatiske sed kontroller av identifiseringsfilter

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
@@ -19,7 +19,7 @@ public class IdentifiseringKontrollService {
     private final EuxService euxService;
     private final PersonSokMetrikker personSokMetrikker;
     private final Unleash unleash;
-    private static final int MAKS_OPPGAVEVERSJON_UTEN_OVERSTYRING = 3;
+    private static final int MAKS_OPPGAVEVERSJON_UTEN_OVERSTYRING = 3; // 3 versjon tilsvarer 2 gang hos id og fordeling
 
     public IdentifiseringKontrollService(PersonFasade personFasade, EuxService euxService, PersonSokMetrikker personSokMetrikker, Unleash unleash) {
         this.personFasade = personFasade;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
@@ -28,7 +28,7 @@ public class IdentifiseringKontrollService {
         this.unleash = unleash;
     }
 
-    public IdentifiseringsKontrollResultat kontrollerIdentifisertPerson(String aktørId, String rinaSaksnummer, int oppgaveVersjon) {
+    public IdentifiseringsKontrollResultat kontrollerIdentifisertPerson(String aktørId, String rinaSaksnummer, int oppgaveEndretVersjon) {
         var buc = euxService.hentBuc(rinaSaksnummer);
         var dokumentID = buc.finnFørstMottatteSed()
             .orElseThrow(() -> new NoSuchElementException("Finner ikke første mottatte SED"))
@@ -40,7 +40,7 @@ public class IdentifiseringKontrollService {
         var identifisertPerson = personFasade.hentPerson(aktørId);
 
         if (unleash.isEnabled("melosys.eessi.overstyrIdentifiseringsKontroll")) {
-            if (oppgaveVersjon >= MAKS_OPPGAVEVERSJON_UTEN_OVERSTYRING) {
+            if (oppgaveEndretVersjon >= MAKS_OPPGAVEVERSJON_UTEN_OVERSTYRING) {
                 personSokMetrikker.counter(IdentifiseringsKontrollBegrunnelse.OVERSTYREKONTROLL);
                 return new IdentifiseringsKontrollResultat(Collections.emptyList());
             }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringsKontrollBegrunnelse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringsKontrollBegrunnelse.java
@@ -4,7 +4,8 @@ public enum IdentifiseringsKontrollBegrunnelse {
     FØDSELSDATO("fødselsdato"),
     STATSBORGERSKAP("statsborgerskap"),
     KJØNN("kjønn"),
-    UTENLANDSK_ID("utenlandsk-id");
+    UTENLANDSK_ID("utenlandsk-id"),
+    OVERSTYREKONTROLL("overstyre kontroll");
 
     private final String begrunnelse;
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringsKontrollResultat.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringsKontrollResultat.java
@@ -8,7 +8,8 @@ import lombok.Value;
 @Value
 public class IdentifiseringsKontrollResultat {
 
-    private static final String FEIL_BESKRIVELSE = "Feil i opplysninger av identifisert person: %s";
+    private static final String FEIL_BESKRIVELSE = "-- Automatisk SED-kontroll --\n" + "Feil i opplysninger av identifisert person: %s\n";
+    private static final String OVERSTYRINGSMELDING = "Du kan overføre oppgaven hvis du ser en feil i mottatt SED. \nNB! Dette kan ikke omgjøres. Vennligst kontroller opplysningene før du overfører oppgaven.";
 
     Collection<IdentifiseringsKontrollBegrunnelse> begrunnelser;
 
@@ -21,6 +22,6 @@ public class IdentifiseringsKontrollResultat {
             .map(IdentifiseringsKontrollBegrunnelse::getBegrunnelse)
             .collect(Collectors.joining(", "));
 
-        return String.format(FEIL_BESKRIVELSE, manglerTekst);
+        return String.format(FEIL_BESKRIVELSE, manglerTekst) + OVERSTYRINGSMELDING;
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
@@ -75,17 +75,17 @@ public class OppgaveEndretConsumer {
     }
 
     private void kontrollerIdentifiseringOgOppdaterOppgave(String rinaSaksnummer,
-                                                           OppgaveEndretHendelse oppgave) {
-        var kontrollResultat = identifiseringKontrollService.kontrollerIdentifisertPerson(oppgave.hentAktørID(), rinaSaksnummer, oppgave.getVersjon());
+                                                           OppgaveEndretHendelse oppgaveEndretHendelse) {
+        var kontrollResultat = identifiseringKontrollService.kontrollerIdentifisertPerson(oppgaveEndretHendelse.hentAktørID(), rinaSaksnummer, oppgaveEndretHendelse.getVersjon());
         if (kontrollResultat.erIdentifisert()) {
-            log.info("BUC {} identifisert av oppgave {}", rinaSaksnummer, oppgave.getId());
-            bucIdentifisertService.lagreIdentifisertPerson(rinaSaksnummer, personFasade.hentNorskIdent(oppgave.hentAktørID()));
-            oppgaveService.ferdigstillOppgave(oppgave.getId().toString(), oppgave.getVersjon());
+            log.info("BUC {} identifisert av oppgave {}", rinaSaksnummer, oppgaveEndretHendelse.getId());
+            bucIdentifisertService.lagreIdentifisertPerson(rinaSaksnummer, personFasade.hentNorskIdent(oppgaveEndretHendelse.hentAktørID()));
+            oppgaveService.ferdigstillOppgave(oppgaveEndretHendelse.getId().toString(), oppgaveEndretHendelse.getVersjon());
         } else {
-            log.info("Oppgave {} tilhørende rina-sak {} ikke identifisert. Feilet på: {}", oppgave.getId(), rinaSaksnummer, kontrollResultat.getBegrunnelser());
+            log.info("Oppgave {} tilhørende rina-sak {} ikke identifisert. Feilet på: {}", oppgaveEndretHendelse.getId(), rinaSaksnummer, kontrollResultat.getBegrunnelser());
             oppgaveService.flyttOppgaveTilIdOgFordeling(
-                oppgave.getId().toString(),
-                oppgave.getVersjon(),
+                oppgaveEndretHendelse.getId().toString(),
+                oppgaveEndretHendelse.getVersjon(),
                 kontrollResultat.hentFeilIOpplysningerTekst());
         }
     }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
@@ -76,7 +76,7 @@ public class OppgaveEndretConsumer {
 
     private void kontrollerIdentifiseringOgOppdaterOppgave(String rinaSaksnummer,
                                                            OppgaveEndretHendelse oppgave) {
-        var kontrollResultat = identifiseringKontrollService.kontrollerIdentifisertPerson(oppgave.hentAktørID(), rinaSaksnummer);
+        var kontrollResultat = identifiseringKontrollService.kontrollerIdentifisertPerson(oppgave.hentAktørID(), rinaSaksnummer, oppgave.getVersjon());
         if (kontrollResultat.erIdentifisert()) {
             log.info("BUC {} identifisert av oppgave {}", rinaSaksnummer, oppgave.getId());
             bucIdentifisertService.lagreIdentifisertPerson(rinaSaksnummer, personFasade.hentNorskIdent(oppgave.hentAktørID()));

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonKontroller.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonKontroller.java
@@ -33,10 +33,7 @@ class PersonKontroller {
         return personModell.getUtenlandskId().stream().anyMatch(utenlandskId::equals);
     }
 
-    public static boolean harSammeKjønn(PersonModell identifisertPerson, Person sedPerson) {
-        if (sedPerson.getKjoenn() == Kjønn.U) {
-            return true;
-        }
-        return identifisertPerson.getKjønn() == sedPerson.getKjoenn().tilDomene();
+    public static boolean harUkjentEllerSammeKjønn(PersonModell identifisertPerson, Person sedPerson) {
+        return sedPerson.getKjoenn() == Kjønn.U || identifisertPerson.getKjønn() == sedPerson.getKjoenn().tilDomene();
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonKontroller.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonKontroller.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import lombok.experimental.UtilityClass;
 import no.nav.melosys.eessi.models.person.PersonModell;
 import no.nav.melosys.eessi.models.person.UtenlandskId;
+import no.nav.melosys.eessi.models.sed.nav.Kjønn;
 import no.nav.melosys.eessi.models.sed.nav.Person;
 import no.nav.melosys.eessi.service.personsok.PersonsokKriterier;
 
@@ -33,6 +34,9 @@ class PersonKontroller {
     }
 
     public static boolean harSammeKjønn(PersonModell identifisertPerson, Person sedPerson) {
+        if (sedPerson.getKjoenn() == Kjønn.U) {
+            return true;
+        }
         return identifisertPerson.getKjønn() == sedPerson.getKjoenn().tilDomene();
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonSokMetrikker.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/PersonSokMetrikker.java
@@ -33,6 +33,8 @@ class PersonSokMetrikker {
     private static final String STATSBORGERSKAP = "statsborgerskap";
     private static final String UTENLANDSK_ID = "utenlandskid";
 
+    private static final String OVERSTYREKONTROLL = "overstyreKontroll";
+
     private static final Map<SoekBegrunnelse, Counter> SØKBEGRUNNELSE_TELLERE = new EnumMap<>(SoekBegrunnelse.class);
     private static final Map<IdentifiseringsKontrollBegrunnelse, Counter> IDENTIFISERINGS_KONTROLL_BEGRUNNELSE_TELLERE = new EnumMap<>(IdentifiseringsKontrollBegrunnelse.class);
 
@@ -49,6 +51,7 @@ class PersonSokMetrikker {
         IDENTIFISERINGS_KONTROLL_BEGRUNNELSE_TELLERE.put(IdentifiseringsKontrollBegrunnelse.KJØNN, Metrics.counter(IDENTIFISERING_KONTROLL, KEY_BEGRUNNELSE, KJØNN));
         IDENTIFISERINGS_KONTROLL_BEGRUNNELSE_TELLERE.put(IdentifiseringsKontrollBegrunnelse.STATSBORGERSKAP, Metrics.counter(IDENTIFISERING_KONTROLL, KEY_BEGRUNNELSE, STATSBORGERSKAP));
         IDENTIFISERINGS_KONTROLL_BEGRUNNELSE_TELLERE.put(IdentifiseringsKontrollBegrunnelse.UTENLANDSK_ID, Metrics.counter(IDENTIFISERING_KONTROLL, KEY_BEGRUNNELSE, UTENLANDSK_ID));
+        IDENTIFISERINGS_KONTROLL_BEGRUNNELSE_TELLERE.put(IdentifiseringsKontrollBegrunnelse.OVERSTYREKONTROLL, Metrics.counter(IDENTIFISERING_KONTROLL, KEY_BEGRUNNELSE, OVERSTYREKONTROLL));
     }
 
     void counter(final SoekBegrunnelse soekBegrunnelse) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
@@ -104,7 +104,7 @@ class IdentifiseringKontrollServiceTest {
     @Test
     void kontrollerIdentifisertPerson_personSamstemmerMedSed_identifisert() {
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.build());
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer))
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 1))
             .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
             .containsExactly(true, Collections.emptyList());
     }
@@ -113,7 +113,16 @@ class IdentifiseringKontrollServiceTest {
     void kontrollerIdentifiseringPerson_personMedUkjentKjonn_identifisert() {
         sedPerson.setKjoenn(no.nav.melosys.eessi.models.sed.nav.Kjønn.U);
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.build());
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID,rinaSaksnummer))
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 1))
+            .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
+            .containsExactly(true, Collections.emptyList());
+    }
+
+    @Test
+    void kontrollerIdentifiseringsPerson_personOverstyrtAvIDogFordeling_identifisert() {
+        sedPerson.setFoedselsdato(LocalDate.now().minusMonths(3).toString());
+        when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.build());
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 3))
             .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
             .containsExactly(true, Collections.emptyList());
     }
@@ -121,7 +130,7 @@ class IdentifiseringKontrollServiceTest {
     @Test
     void kontrollerIdentifisertPerson_personHarIkkeRiktigStatsborgerskap_ikkeIdentifisert() {
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.statsborgerskapLandkodeISO2(Set.of("DK")).build());
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer))
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 1))
             .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
             .containsExactly(false, List.of(IdentifiseringsKontrollBegrunnelse.STATSBORGERSKAP));
     }
@@ -129,7 +138,7 @@ class IdentifiseringKontrollServiceTest {
     @Test
     void kontrollerIdentifisertPerson_personHarFeilKjønn_ikkeIdentifisert() {
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.kjønn(Kjønn.MANN).build());
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer))
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 1))
             .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
             .containsExactly(false, List.of(IdentifiseringsKontrollBegrunnelse.KJØNN));
     }
@@ -137,7 +146,7 @@ class IdentifiseringKontrollServiceTest {
     @Test
     void kontrollerIdentifisertPerson_personHarIkkeRiktigFødselsdato_ikkeIdentifisert() {
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.fødselsdato(LocalDate.now().minusYears(3)).build());
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer))
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 1))
             .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
             .containsExactly(false, List.of(IdentifiseringsKontrollBegrunnelse.FØDSELSDATO));
     }
@@ -145,7 +154,7 @@ class IdentifiseringKontrollServiceTest {
     @Test
     void kontrollerIdentifisertPerson_personHarIkkeRiktigUtenlandskId_ikkeIdentifisert() {
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.utenlandskId(Set.of(new UtenlandskId("feil-pin", avsenderLand))).build());
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer))
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 1))
             .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
             .containsExactly(false, List.of(IdentifiseringsKontrollBegrunnelse.UTENLANDSK_ID));
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
@@ -110,6 +110,15 @@ class IdentifiseringKontrollServiceTest {
     }
 
     @Test
+    void kontrollerIdentifiseringPerson_personMedUkjentKjonn_identifisert() {
+        sedPerson.setKjoenn(no.nav.melosys.eessi.models.sed.nav.Kjønn.U);
+        when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.build());
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID,rinaSaksnummer))
+            .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
+            .containsExactly(true, Collections.emptyList());
+    }
+
+    @Test
     void kontrollerIdentifisertPerson_personHarIkkeRiktigStatsborgerskap_ikkeIdentifisert() {
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.statsborgerskapLandkodeISO2(Set.of("DK")).build());
         assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer))

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/OppgaveEndretMottakTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/OppgaveEndretMottakTestIT.java
@@ -1,5 +1,9 @@
 package no.nav.melosys.eessi;
 
+import java.time.Duration;
+import java.util.Random;
+import java.util.UUID;
+
 import no.finn.unleash.FakeUnleash;
 import no.nav.melosys.eessi.integration.oppgave.HentOppgaveDto;
 import no.nav.melosys.eessi.integration.pdl.dto.PDLSokPerson;
@@ -9,16 +13,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.Duration;
-import java.util.Random;
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.never;
 
 public class OppgaveEndretMottakTestIT extends ComponentTestBase {
 
@@ -101,7 +100,6 @@ public class OppgaveEndretMottakTestIT extends ComponentTestBase {
         kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, FNR ,"2", rinaSaksnummer)).get();
         kafkaTestConsumer.doWait(5_000L);
 
-        //verify(oppgaveConsumer, timeout(4000)).oppdaterOppgave(eq(oppgaveID), any());
         verify(oppgaveConsumer, never()).oppdaterOppgave(anyString(),any());
         assertThat(hentMelosysEessiRecords()).isEmpty();
     }


### PR DESCRIPTION
Overstyrer identifiseringskontroll mot sed dersom ID og Fordeling har oversendt oppgave 2 ganger 