### PR TITLE
MEL-4877-Legger til updateVersjonNumberBy1 i JPArepo for å oppdatere versjon

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
@@ -19,7 +19,7 @@ public class IdentifiseringKontrollService {
     private final EuxService euxService;
     private final PersonSokMetrikker personSokMetrikker;
     private final Unleash unleash;
-    private static final int MAKS_OPPGAVEVERSJON_UTEN_OVERSTYRING = 3; // 3 versjon tilsvarer 2 gang hos id og fordeling
+    private static final int MAKS_OPPGAVEVERSJON_UTEN_OVERSTYRING = 2; // 2 versjon tilsvarer 2 gang hos id og fordeling
 
     public IdentifiseringKontrollService(PersonFasade personFasade, EuxService euxService, PersonSokMetrikker personSokMetrikker, Unleash unleash) {
         this.personFasade = personFasade;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/OppgaveEndretConsumer.java
@@ -95,11 +95,9 @@ public class OppgaveEndretConsumer extends AbstractConsumerSeekAware {
                 oppgaveEndretHendelse.getId().toString(),
                 oppgaveEndretHendelse.getVersjon(),
                 kontrollResultat.hentFeilIOpplysningerTekst());
-            bucIdentifiseringOppgRepository.save(BucIdentifiseringOppg.builder()
-                .rinaSaksnummer(rinaSaksnummer)
-                .oppgaveId(oppgaveEndretHendelse.getId().toString())
-                .versjon(versjon + 1)
-                .build());
+            bucIdentifiseringOppgRepository.updateVersjonNumberBy1(
+                oppgaveEndretHendelse.getId().toString(),
+                rinaSaksnummer);
         }
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/BucIdentifiseringOppgRepository.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/BucIdentifiseringOppgRepository.java
@@ -5,9 +5,17 @@ import java.util.Optional;
 
 import no.nav.melosys.eessi.models.BucIdentifiseringOppg;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface BucIdentifiseringOppgRepository extends JpaRepository<BucIdentifiseringOppg, Long> {
 
     Collection<BucIdentifiseringOppg> findByRinaSaksnummer(String rinaSaksnummer);
     Optional<BucIdentifiseringOppg> findByOppgaveId(String oppgaveID);
+
+    @Transactional
+    @Modifying
+    @Query("update buc_identifisering_oppg b set b.versjon = b.versjon+1 where b.oppgaveId = ?1 and b.rinaSaksnummer = ?2")
+    int updateVersjonNumberBy1(String oppgaveId, String rinasaksnummer);
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
@@ -126,7 +126,7 @@ class IdentifiseringKontrollServiceTest {
     void kontrollerIdentifiseringsPerson_personOverstyrtAvIDogFordeling_identifisert() {
         sedPerson.setFoedselsdato(LocalDate.now().minusMonths(3).toString());
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.build());
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 3))
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 2))
             .extracting(IdentifiseringsKontrollResultat::erIdentifisert, IdentifiseringsKontrollResultat::getBegrunnelser)
             .containsExactly(true, Collections.emptyList());
     }
@@ -139,7 +139,7 @@ class IdentifiseringKontrollServiceTest {
         sedPerson.setFoedselsdato(LocalDate.now().minusMonths(3).toString());
         when(personFasade.hentPerson(aktørID)).thenReturn(personBuilder.build());
 
-        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 2)
+        assertThat(identifiseringKontrollService.kontrollerIdentifisertPerson(aktørID, rinaSaksnummer, 1)
             .hentFeilIOpplysningerTekst()).isEqualTo(identifiseringsKontrollResultatData.hentFeilIOpplysningerTekst());
     }
 


### PR DESCRIPTION
oppdaterer versjonsnummer på identifisersoppgave og ikke lagre ny rad i tabellen. I tillegg reduserer vi antallet vi sjekker mot til 2 da dette vil være riktigere når vi setter versjon = 1 ved mottak av sed