### PR TITLE
Filtrerer bort null-verdier før findFirst i finnLovvalgsland()

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedDataDto.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedDataDto.java
@@ -2,6 +2,7 @@ package no.nav.melosys.eessi.controller.dto;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -12,6 +13,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SedDataDto extends SedGrunnlagDto {
+
     private Bruker bruker;
     private Adresse kontaktadresse;
     private Adresse oppholdsadresse;
@@ -40,6 +42,7 @@ public class SedDataDto extends SedGrunnlagDto {
     public Optional<String> finnLovvalgsland() {
         return getLovvalgsperioder().stream()
             .map(Lovvalgsperiode::getLovvalgsland)
+            .filter(Objects::nonNull)
             .findFirst();
     }
 


### PR DESCRIPTION
[MELOSYS-5053](https://jira.adeo.no/browse/MELOSYS-5053)

Fikser feil ved forhåndsvisning i EESSI der man har brukt findFirst litt tvetydelig. Forårsaket NullpointerException fordi findFirst traff på null.

https://stackoverflow.com/questions/32466799/why-does-findfirst-throw-a-nullpointerexception-if-the-first-element-it-finds