### PR TITLE
Hånter PDL kode for ukjent: XUK

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -20,6 +20,7 @@ public final class LandkodeMapper {
         Arrays.stream(Locale.getISOCountries()).forEach(c -> ISO3_ISO2_LANDKODER_MAP.put(new Locale("", c).getISO3Country(), c));
         ISO3_ISO2_LANDKODER_MAP.put("XXX", "XS"); //Statsløs
         ISO3_ISO2_LANDKODER_MAP.put("???", "???"); //Ukjent
+        ISO3_ISO2_LANDKODER_MAP.put("XUK", "XUK"); //Ukjent
     }
 
     public static String mapTilLandkodeIso2(String landkodeIso3) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
@@ -35,5 +35,6 @@ class LandkodeMapperTest {
     void getIso2_medIkkeISOStandardKoder_forventSammeKodeTilbake() {
         assertThat(LandkodeMapper.mapTilLandkodeIso2("???")).isEqualTo("???");
         assertThat(LandkodeMapper.mapTilLandkodeIso2("XXX")).isEqualTo("XS");
+        assertThat(LandkodeMapper.mapTilLandkodeIso2("XUK")).isEqualTo("XUK");
     }
 }


### PR DESCRIPTION
Vi får masse feil i [loggen](https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:application,negate:!f,params:(query:melosys-eessi),type:phrase),query:(match_phrase:(application:melosys-eessi)))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:kuery,query:'team:teammelosys%20and%20envclass:p%20and%20level:Error%20and%20application:%20%22melosys-eessi%22%20and%20stack_trace:%20%22Landkode%20XUK%20ble%20ikke%20funnet%22'),sort:!())) siden person ikke kan lastes fra PDL når ukjent landskode brukes.

Forslag til løsning er å mappe XUK->XUK som i [PDL dok ](https://pdl-docs.dev.intern.nav.no/ekstern/index.html#_innflytting)er kode for ukjent


