### PR TITLE
5198: Setter pod memory limit høyere enn JVM heap size

### DIFF
--- a/deploy/nais.yaml
+++ b/deploy/nais.yaml
@@ -23,7 +23,7 @@ spec:
   resources:
     limits:
       cpu: 500m
-      memory: 2048Mi
+      memory: 2560Mi
     requests:
       cpu: 200m
       memory: 1024Mi


### PR DESCRIPTION
Melosys-eessi manglet miljøvariabel for å overstyre defaultverdier til JVM heap size. Siden vi egentlig ikke vet hvor mye minne melosys-eessi behøver, må vi ha en høy verdi, og justere det ned senere. 

Både JVM heap size og pod-minne er satt til 2gb. JVM heap size burde alltid være mindre enn total allokert minne. Sett JVM heap size til 2gb, og Pod-minne til 2.5gb. Vi må samle data om hvor mye melosys-eessi bruker over tid, og justere det et par måneder etterpå.

https://jira.adeo.no/browse/MELOSYS-5198