### PR TITLE
5219 Ignorerer SED med X100, også når man identifiserer alle SED for BUC

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertService.java
@@ -32,11 +32,14 @@ public class BehandleBucIdentifisertService {
     @Transactional
     public void bucIdentifisert(String rinaSaksnummer, String personIdent) {
         sedMottattHendelseRepository.findAllByRinaSaksnummerAndPublisertKafkaSortedByMottattDato(rinaSaksnummer, false)
-            .stream()
             .forEach(sedMottattHendelse -> sedIdentifisert(sedMottattHendelse, personIdent));
     }
 
     private void sedIdentifisert(SedMottattHendelse sedMottattHendelse, String personIdent) {
+        if (sedMottattHendelse.getSedHendelse().erX100()) {
+            log.info("Ignorerer identifisert SED {} av typen X100", sedMottattHendelse.getSedHendelse().getSedId());
+            return;
+        }
         if (sedMottattHendelse.getJournalpostId() == null) {
             sedMottattHendelse.setJournalpostId(opprettJournalpost(sedMottattHendelse, personIdent));
         }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertServiceTest.java
@@ -101,12 +101,11 @@ class BehandleBucIdentifisertServiceTest {
     void bucIdentifisert_SEDErX100_ignoreres() {
         // Første SED som må identifiseres journalføres sammen med opprettelse av oppgave til ID fordeling
         var sedAlleredeJournalført = lagSedMottattHendelse("1", RINA_SAKSNUMMER, RINA_DOKUMENT_ID, JOURNALPOST_ID, false);
-        // Den påfølgende SEDen blir ignorert siden den er X100
-        var sed2 = lagSedMottattHendelse("2", RINA_SAKSNUMMER, RINA_DOKUMENT_ID, null, false);
-        sed2.getSedHendelse().setSedType(SedType.X100.name());
+        var sedSomSkalIgnoreres = lagSedMottattHendelse("2", RINA_SAKSNUMMER, RINA_DOKUMENT_ID, null, false);
+        sedSomSkalIgnoreres.getSedHendelse().setSedType(SedType.X100.name());
 
         when(sedMottattHendelseRepository.findAllByRinaSaksnummerAndPublisertKafkaSortedByMottattDato(RINA_SAKSNUMMER, false))
-            .thenReturn(List.of(sedAlleredeJournalført, sed2));
+            .thenReturn(List.of(sedAlleredeJournalført, sedSomSkalIgnoreres));
         when(melosysEessiMeldingMapperFactory.getMapper(any())).thenReturn(new DefaultMapper());
         when(personFasade.hentAktoerId(FNR)).thenReturn(AKTOER_ID);
         when(euxService.hentSed(RINA_SAKSNUMMER, RINA_DOKUMENT_ID)).thenReturn(lagSED());
@@ -123,7 +122,7 @@ class BehandleBucIdentifisertServiceTest {
         assertThat(sedAlleredeJournalført.isPublisertKafka()).isTrue();
         assertThat(sedAlleredeJournalført.getJournalpostId()).isEqualTo(JOURNALPOST_ID);
 
-        assertThat(sed2.isPublisertKafka()).isFalse();
+        assertThat(sedSomSkalIgnoreres.isPublisertKafka()).isFalse();
     }
 
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/BehandleBucIdentifisertServiceTest.java
@@ -7,6 +7,7 @@ import no.nav.melosys.eessi.integration.PersonFasade;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
 import no.nav.melosys.eessi.kafka.producers.MelosysEessiAivenProducer;
 import no.nav.melosys.eessi.models.SedMottattHendelse;
+import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.nav.Nav;
 import no.nav.melosys.eessi.models.vedlegg.SedMedVedlegg;
@@ -22,14 +23,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static no.nav.melosys.eessi.models.SedType.A003;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class BehandleBucIdentifisertServiceTest {
+class BehandleBucIdentifisertServiceTest {
 
     private final String RINA_SAKSNUMMER = "123456";
     private final String RINA_DOKUMENT_ID = "7890";
@@ -97,13 +97,43 @@ public class BehandleBucIdentifisertServiceTest {
         assertThat(sed3.getJournalpostId()).isEqualTo(JOURNALPOST_ID_3);
     }
 
+    @Test
+    void bucIdentifisert_SEDErX100_ignoreres() {
+        // Første SED som må identifiseres journalføres sammen med opprettelse av oppgave til ID fordeling
+        var sedAlleredeJournalført = lagSedMottattHendelse("1", RINA_SAKSNUMMER, RINA_DOKUMENT_ID, JOURNALPOST_ID, false);
+        // Den påfølgende SEDen blir ignorert siden den er X100
+        var sed2 = lagSedMottattHendelse("2", RINA_SAKSNUMMER, RINA_DOKUMENT_ID, null, false);
+        sed2.getSedHendelse().setSedType(SedType.X100.name());
+
+        when(sedMottattHendelseRepository.findAllByRinaSaksnummerAndPublisertKafkaSortedByMottattDato(RINA_SAKSNUMMER, false))
+            .thenReturn(List.of(sedAlleredeJournalført, sed2));
+        when(melosysEessiMeldingMapperFactory.getMapper(any())).thenReturn(new DefaultMapper());
+        when(personFasade.hentAktoerId(FNR)).thenReturn(AKTOER_ID);
+        when(euxService.hentSed(RINA_SAKSNUMMER, RINA_DOKUMENT_ID)).thenReturn(lagSED());
+        when(euxService.sedErEndring(RINA_DOKUMENT_ID, RINA_SAKSNUMMER)).thenReturn(false);
+        when(saksrelasjonService.finnVedRinaSaksnummer(RINA_SAKSNUMMER)).thenReturn(Optional.empty());
+
+
+        behandleBucIdentifisertService.bucIdentifisert(RINA_SAKSNUMMER, FNR);
+
+
+        verify(sedMottattHendelseRepository, never()).save(any());
+        verify(melosysEessiAivenProducer).publiserMelding(any());
+
+        assertThat(sedAlleredeJournalført.isPublisertKafka()).isTrue();
+        assertThat(sedAlleredeJournalført.getJournalpostId()).isEqualTo(JOURNALPOST_ID);
+
+        assertThat(sed2.isPublisertKafka()).isFalse();
+    }
+
+
     private SedMottattHendelse lagSedMottattHendelse(String sedID, String rinaSaksnummer, String rinaDokumentID, String journalpostID, boolean publisertKafka) {
         return SedMottattHendelse.builder()
             .sedHendelse(SedHendelse.builder()
                 .sedId(sedID)
                 .rinaSakId(rinaSaksnummer)
                 .rinaDokumentId(rinaDokumentID)
-                .sedType(A003.name())
+                .sedType(SedType.A003.name())
                 .avsenderId("DK:88855")
                 .build())
             .journalpostId(journalpostID)


### PR DESCRIPTION
Tidligere relevant PR: https://github.com/navikt/melosys-eessi/pull/478

https://jira.adeo.no/browse/MELOSYS-5219

https://nav-it.slack.com/archives/CPSMP2GKT/p1659370762184569