### PR TITLE
@EmbeddedKafka for hver komptest

### DIFF
--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestConfig.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/ComponentTestConfig.java
@@ -1,39 +1,15 @@
 package no.nav.melosys.eessi;
 
-import java.util.concurrent.ThreadLocalRandom;
-
 import no.finn.unleash.FakeUnleash;
 import no.finn.unleash.Unleash;
-import no.nav.security.token.support.spring.test.EnableMockOAuth2Server;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Primary;
-import org.springframework.core.annotation.Order;
-import org.springframework.core.env.Environment;
-import org.springframework.kafka.test.EmbeddedKafkaBroker;
 
-@EnableMockOAuth2Server
+@TestConfiguration
 @ComponentScan(basePackageClasses = MelosysEessiApplication.class)
 public class ComponentTestConfig {
-    static {
-        System.setProperty("kafkaPort", String.valueOf(ThreadLocalRandom.current().nextInt(60000, 65535)));
-    }
-
-    @Bean
-    @Order(1)
-    EmbeddedKafkaBroker kafkaEmbedded(Environment env) {
-        EmbeddedKafkaBroker kafka = new EmbeddedKafkaBroker(1, true, 1,
-            "eessibasis-sedmottatt-v1",
-            "eessibasis-sedsendt-v1",
-            "oppgave-endret",
-            "teammelosys.eessi.v1-local");
-        kafka.kafkaPorts(Integer.parseInt(env.getRequiredProperty("kafkaPort")));
-        kafka.brokerProperty("offsets.topic.replication.factor", (short) 1);
-        kafka.brokerProperty("transaction.state.log.replication.factor", (short) 1);
-        kafka.brokerProperty("transaction.state.log.min.isr", 1);
-
-        return kafka;
-    }
 
     @Bean
     @Primary

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/KafkaAdminTjenesteTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/KafkaAdminTjenesteTestIT.java
@@ -82,10 +82,10 @@ public class KafkaAdminTjenesteTestIT extends ComponentTestBase {
         when(oppgaveConsumer.hentOppgave(oppgaveID2)).thenReturn(oppgaveDto2);
         when(oppgaveConsumer.hentOppgave(oppgaveID3)).thenReturn(oppgaveDto3);
 
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, FNR, "1", rinaSaksnummer)).get();
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID1, FNR, "1", rinaSaksnummer)).get();
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID2, FNR, "1", rinaSaksnummer)).get();
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID3, FNR, "1", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, "1", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID1, "1", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID2, "1", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID3, "1", rinaSaksnummer)).get();
 
         verify(oppgaveConsumer, timeout(1000).times(4)).hentOppgave(anyString());
 

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/KafkaAdminTjenesteTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/KafkaAdminTjenesteTestIT.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.*;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-public class KafkaAdminTjenesteTestIT extends ComponentTestBase {
+class KafkaAdminTjenesteTestIT extends ComponentTestBase {
 
     @LocalServerPort
     private int port;
@@ -82,10 +82,11 @@ public class KafkaAdminTjenesteTestIT extends ComponentTestBase {
         when(oppgaveConsumer.hentOppgave(oppgaveID2)).thenReturn(oppgaveDto2);
         when(oppgaveConsumer.hentOppgave(oppgaveID3)).thenReturn(oppgaveDto3);
 
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, "1", rinaSaksnummer)).get();
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID1, "1", rinaSaksnummer)).get();
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID2, "1", rinaSaksnummer)).get();
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID3, "1", rinaSaksnummer)).get();
+        String VERSJON = "1";
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, VERSJON, rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID1, VERSJON, rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID2, VERSJON, rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID3, VERSJON, rinaSaksnummer)).get();
 
         verify(oppgaveConsumer, timeout(1000).times(4)).hentOppgave(anyString());
 

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/OppgaveEndretMottakTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/OppgaveEndretMottakTestIT.java
@@ -33,7 +33,7 @@ public class OppgaveEndretMottakTestIT extends ComponentTestBase {
         final var oppgaveDto = new HentOppgaveDto(oppgaveID, "AAPEN", 1);
         oppgaveDto.setStatus("OPPRETTET");
 
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
 
         when(euxConsumer.hentSed(anyString(), anyString())).thenReturn(mockData.sed(FØDSELSDATO, STATSBORGERSKAP, null));
         when(pdlConsumer.søkPerson(any())).thenReturn(new PDLSokPerson());
@@ -54,7 +54,7 @@ public class OppgaveEndretMottakTestIT extends ComponentTestBase {
         oppgaveDto.setVersjon(2);
 
         kafkaTestConsumer.reset(1);
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, FNR, "1", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, "1", rinaSaksnummer)).get();
         kafkaTestConsumer.doWait(5_000L);
 
         verify(oppgaveConsumer, never()).oppdaterOppgave(anyString(), any());
@@ -68,7 +68,7 @@ public class OppgaveEndretMottakTestIT extends ComponentTestBase {
         final var oppgaveDto = new HentOppgaveDto(oppgaveID, "AAPEN", 1);
         oppgaveDto.setStatus("OPPRETTET");
 
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
 
         when(euxConsumer.hentSed(anyString(), anyString())).thenReturn(mockData.sed(FØDSELSDATO, STATSBORGERSKAP, null));
         when(pdlConsumer.søkPerson(any())).thenReturn(new PDLSokPerson());
@@ -90,7 +90,7 @@ public class OppgaveEndretMottakTestIT extends ComponentTestBase {
         oppgaveDto.setStatus("FERDIGSTILT");
 
         kafkaTestConsumer.reset(1);
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, FNR, "2", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, "2", rinaSaksnummer)).get();
         kafkaTestConsumer.doWait(5_000L);
 
         verify(oppgaveConsumer, never()).oppdaterOppgave(anyString(), any());

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedMottakTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedMottakTestIT.java
@@ -37,7 +37,7 @@ class SedMottakTestIT extends ComponentTestBase {
         final var sedID = UUID.randomUUID().toString();
         when(euxConsumer.hentSed(anyString(), anyString())).thenReturn(mockData.sed(FØDSELSDATO, STATSBORGERSKAP, FNR));
 
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
 
         // Venter på to Kafka-meldinger: den vi selv legger på topic som input, og den som kommer som output
         kafkaTestConsumer.reset(2);
@@ -57,7 +57,7 @@ class SedMottakTestIT extends ComponentTestBase {
         søkHits.setIdenter(Collections.singleton(new PDLIdent(FOLKEREGISTERIDENT, FNR)));
         pdlSøkPerson.setHits(Collections.singleton(søkHits));
         when(pdlConsumer.søkPerson(any())).thenReturn(pdlSøkPerson);
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
 
         kafkaTestConsumer.reset(2);
         kafkaTemplate.send(lagSedMottattRecord(mockData.sedHendelse(rinaSaksnummer, sedID, null))).get();
@@ -74,7 +74,7 @@ class SedMottakTestIT extends ComponentTestBase {
         final var oppgaveDto = new HentOppgaveDto(oppgaveID, "AAPEN", 1);
         oppgaveDto.setStatus("OPPRETTET");
 
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
 
         when(euxConsumer.hentSed(anyString(), anyString())).thenReturn(mockData.sed(FØDSELSDATO, STATSBORGERSKAP, null));
         when(pdlConsumer.søkPerson(any())).thenReturn(new PDLSokPerson());
@@ -95,7 +95,7 @@ class SedMottakTestIT extends ComponentTestBase {
         assertThat(bucIdentifiseringOppgRepository.findByOppgaveId(oppgaveID)).isPresent();
 
         kafkaTestConsumer.reset(3);
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, FNR, "1", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, "1", rinaSaksnummer)).get();
         kafkaTestConsumer.doWait(5_000L);
 
         verify(oppgaveConsumer, timeout(4000)).oppdaterOppgave(eq(oppgaveID), any());
@@ -111,7 +111,7 @@ class SedMottakTestIT extends ComponentTestBase {
         final var oppgaveDto = new HentOppgaveDto(oppgaveID, "AAPEN", 1);
         oppgaveDto.setStatus("OPPRETTET");
 
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
 
         when(euxConsumer.hentSed(anyString(), anyString())).thenReturn(mockData.sed(FØDSELSDATO, STATSBORGERSKAP, FNR));
         when(pdlConsumer.søkPerson(any())).thenReturn(new PDLSokPerson());
@@ -136,7 +136,7 @@ class SedMottakTestIT extends ComponentTestBase {
         final var oppgaveDto = new HentOppgaveDto(oppgaveID, "AAPEN", 1);
         oppgaveDto.setStatus("OPPRETTET");
 
-        mockPerson(FNR, AKTOER_ID, FØDSELSDATO.minusYears(1), "DK");
+        mockPerson(FØDSELSDATO.minusYears(1), "DK");
 
         when(euxConsumer.hentSed(anyString(), anyString())).thenReturn(mockData.sed(FØDSELSDATO, STATSBORGERSKAP, null));
         when(pdlConsumer.søkPerson(any())).thenReturn(new PDLSokPerson());
@@ -158,7 +158,7 @@ class SedMottakTestIT extends ComponentTestBase {
 
         //Forventer kun én melding, som er oppgave-endret record
         kafkaTestConsumer.reset(1);
-        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, FNR, "1", rinaSaksnummer)).get();
+        kafkaTemplate.send(lagOppgaveIdentifisertRecord(oppgaveID, "1", rinaSaksnummer)).get();
         kafkaTestConsumer.doWait(5_000L);
 
         verify(oppgaveConsumer, timeout(4000)).oppdaterOppgave(eq(oppgaveID), any());

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedSendtTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedSendtTestIT.java
@@ -36,7 +36,7 @@ class SedSendtTestIT extends ComponentTestBase {
 
     @Test
     void sedSendt_saksrelasjonFinnes_journalpostOpprettesOgFerdigstilles() throws Exception {
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
         mockArkivsak();
         lagFagsakRinasakKobling();
 
@@ -53,7 +53,7 @@ class SedSendtTestIT extends ComponentTestBase {
 
     @Test
     void sedSendt_feilerVedOpprettelseAvJournalpostFørsteGang_prøverIgjen() throws Exception {
-        mockPerson(FNR, AKTOER_ID);
+        mockPerson();
         mockArkivsak();
         lagFagsakRinasakKobling();
 

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedSendtTestIT.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/SedSendtTestIT.java
@@ -92,7 +92,7 @@ class SedSendtTestIT extends ComponentTestBase {
     }
 
     protected ProducerRecord<String, Object> lagSedSendtRecord(SedHendelse sedHendelse) {
-        return new ProducerRecord<>("eessibasis-sedsendt-v1", "key", sedHendelse);
+        return new ProducerRecord<>(EESSIBASIS_SEDSENDT_V_1, "key", sedHendelse);
     }
 
 }

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/utils/KafkaTestConfig.java
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/utils/KafkaTestConfig.java
@@ -9,16 +9,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 
 @Slf4j
-@Configuration
+@TestConfiguration
 @ComponentScan
 @ConditionalOnClass({
         KafkaListener.class,
@@ -27,7 +27,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 })
 @EnableConfigurationProperties(KafkaTestProperties.class)
 public class KafkaTestConfig {
-    
+
     @Bean("testKafkaListenerContainerFactory")
     ConcurrentKafkaListenerContainerFactory<Object, Object> testKafkaListenerContainerFactory(
             ConcurrentKafkaListenerContainerFactoryConfigurer configurer,

--- a/melosys-eessi-test/src/test/resources/application-test.yaml
+++ b/melosys-eessi-test/src/test/resources/application-test.yaml
@@ -24,7 +24,8 @@ DATABASE_NAME: postgres
 KAFKA_SEDHENDELSER_GROUPID: melosys-eessi-sedHendelser-local
 KAFKA_AIVEN_EESSIMELDING_TOPIC: teammelosys.eessi.v1-local
 KAFKA_OPPGAVE_GROUPID: melosys-eessi-oppgaveHendelser-local
-KAFKA_BROKERS: localhost:${kafkaPort}
+KAFKA_BOOTSTRAP_SERVERS: ${spring.embedded.kafka.brokers}
+KAFKA_BROKERS: ${spring.embedded.kafka.brokers}
 
 spring.datasource:
   username: postgres
@@ -51,7 +52,6 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
-    bootstrap-servers: localhost:${kafkaPort}
     properties:
       schema.registry.url: dummy
       reconnect.backoff.ms: 1000


### PR DESCRIPTION
Av og til feiler komptester med "Socket server failed to bind to localhost:*****: Address already in use."
Det er nok fordi EmbeddedKafkaBroker ble delt mellom testene.
Legg til @EmbeddedKafka på ComponentTestBase i stedet. Litt opprydding i tillegg

Skal løse denne feilen: https://github.com/navikt/melosys-eessi/runs/7626164191?check_suite_focus=true.
Løser dessverre ikke https://github.com/navikt/melosys-eessi/runs/7648286935?check_suite_focus=true fra `KafkaAdminTjenesteTestIT`