### PR TITLE
Ingress annotations for vedlegg

### DIFF
--- a/deploy/nais.yaml
+++ b/deploy/nais.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: teammelosys
   labels:
     team: teammelosys
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "100M"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 spec:
   image: {{image}}
   port: 8080


### PR DESCRIPTION
https://doc.nais.io/nais-application/ingress/#custom-max-body-size

NAIS gikk fra traefik til nginx og dette må settes
for å unngå 413 Payload Too Large.
100M skal være maks i Rina
