### PR TITLE
Bump Java til 17

### DIFF
--- a/.github/workflows/deploy-dev-manuelt.yaml
+++ b/.github/workflows/deploy-dev-manuelt.yaml
@@ -37,10 +37,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '16'
+          java-version: '17'
           distribution: 'adopt-openj9'
       - name: Setup Maven
         uses: actions/cache@v3

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 16
+          java-version: 17
           distribution: 'adopt-openj9'
       - name: Setup Maven
         uses: actions/cache@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,10 +18,10 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Set up JDK 16
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-       java-version: '16'
+       java-version: '17'
        distribution: 'adopt-openj9'
     - name: Build and test
       run: mvn verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/java:16
+FROM navikt/java:17
 LABEL maintainer="Team Melosys"
 
 ENV JAVA_OPTS="${JAVA_OPTS} -Xms512m -Xmx2048m"

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <commons-io.version>2.11.0</commons-io.version>
         <guava.version>31.1-jre</guava.version>
         <hibernate-types.version>2.14.0</hibernate-types.version>
-        <java.version>16</java.version>
+        <java.version>17</java.version>
         <logback-classic.version>1.2.3</logback-classic.version>
         <logstash-encoder.version>5.3</logstash-encoder.version>
         <lombok.version>1.18.22</lombok.version>


### PR DESCRIPTION
Trenger java 17 for nyere versjon av token support som brukes til [azure ad](https://github.com/navikt/melosys-eessi/pull/487)