### PR TITLE
5268 Lagt til logging

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/FraSedA003Mapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/FraSedA003Mapper.java
@@ -1,9 +1,11 @@
 package no.nav.melosys.eessi.service.sed.mapper.fra_sed;
 
+import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA003;
 import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
 
+@Slf4j
 public abstract class FraSedA003Mapper implements NyttLovvalgSedMapper<MedlemskapA003> {
     @Override
     public String hentLovvalgsland(MedlemskapA003 medlemskap) {
@@ -17,7 +19,10 @@ public abstract class FraSedA003Mapper implements NyttLovvalgSedMapper<Medlemska
 
     @Override
     public Boolean sedErEndring(MedlemskapA003 medlemskap) {
-        return !"nei".equalsIgnoreCase(medlemskap.getVedtak().getErendringsvedtak());
+        var erEndring = !"nei".equalsIgnoreCase(medlemskap.getVedtak().getErendringsvedtak());
+        log.info("sedErEndring i A003 er {}, med erendringsvedtak: {} og eropprinneligvedtak: {}", erEndring,
+            medlemskap.getVedtak().getErendringsvedtak(), medlemskap.getVedtak().getEropprinneligvedtak());
+        return erEndring;
     }
 
     @Override

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/melosys_eessi_melding/MelosysEessiMeldingMapperA009.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/melosys_eessi_melding/MelosysEessiMeldingMapperA009.java
@@ -2,6 +2,7 @@ package no.nav.melosys.eessi.service.sed.mapper.fra_sed.melosys_eessi_melding;
 
 import java.time.LocalDate;
 
+import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA009;
 import no.nav.melosys.eessi.models.sed.nav.AapenPeriode;
@@ -10,11 +11,15 @@ import no.nav.melosys.eessi.models.sed.nav.Periode;
 
 import static no.nav.melosys.eessi.models.DatoUtils.tilLocalDate;
 
+@Slf4j
 class MelosysEessiMeldingMapperA009 implements NyttLovvalgEessiMeldingMapper<MedlemskapA009> {
 
     @Override
     public Boolean sedErEndring(MedlemskapA009 medlemskap) {
-        return !"nei".equalsIgnoreCase(medlemskap.getVedtak().getErendringsvedtak());
+        var erEndring = !"nei".equalsIgnoreCase(medlemskap.getVedtak().getErendringsvedtak());
+        log.info("sedErEndring i A009 er {}, med erendringsvedtak: {} og eropprinneligvedtak: {}", erEndring,
+            medlemskap.getVedtak().getErendringsvedtak(), medlemskap.getVedtak().getEropprinneligvedtak());
+        return erEndring;
     }
 
     @Override

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/melosys_eessi_melding/MelosysEessiMeldingMapperA010.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/fra_sed/melosys_eessi_melding/MelosysEessiMeldingMapperA010.java
@@ -1,9 +1,11 @@
 package no.nav.melosys.eessi.service.sed.mapper.fra_sed.melosys_eessi_melding;
 
+import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.kafka.producers.model.Periode;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA010;
 
+@Slf4j
 class MelosysEessiMeldingMapperA010 implements NyttLovvalgEessiMeldingMapper<MedlemskapA010> {
 
     @Override
@@ -24,7 +26,10 @@ class MelosysEessiMeldingMapperA010 implements NyttLovvalgEessiMeldingMapper<Med
 
     @Override
     public Boolean sedErEndring(MedlemskapA010 medlemskap) {
-        return "nei".equalsIgnoreCase(medlemskap.getVedtak().getEropprinneligvedtak());
+        var erEndring = "nei".equalsIgnoreCase(medlemskap.getVedtak().getEropprinneligvedtak());
+        log.info("sedErEndring i A010 er {}, med erendringsvedtak: {} og eropprinneligvedtak: {}", erEndring,
+            medlemskap.getVedtak().getErendringsvedtak(), medlemskap.getVedtak().getEropprinneligvedtak());
+        return erEndring;
     }
 
     public MedlemskapA010 hentMedlemskap(SED sed) {


### PR DESCRIPTION
Ref: https://jira.adeo.no/browse/MELOSYS-5268

Lagt til logging i sedErEndring for A003, A009, og A010 for å sikre at vi kan feilsøke nåværende og potensielt fremtidige feil som følge av kompleksiteten av hvilke verdier vi kan forvente på disse.