### PR TITLE
5268 Har endret tilbake utgående SED vedtak data som ble rettet basert på …

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedGrunnlagDto.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/SedGrunnlagDto.java
@@ -16,4 +16,5 @@ public class SedGrunnlagDto {
     private List<Arbeidssted> arbeidssteder;
     private List<Lovvalgsperiode> lovvalgsperioder;
     private String ytterligereInformasjon;
+    private String gjeldenderegler;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
@@ -22,14 +22,14 @@ public interface LovvalgSedMapper<T extends Medlemskap> extends SedMapper {
 
     default void setVedtaksdata(Vedtak vedtak, VedtakDto vedtakDto) {
         if (vedtakDto != null && !vedtakDto.isErFørstegangsvedtak()) {
-            vedtak.setEropprinneligvedtak(null); // nei
-            vedtak.setErendringsvedtak(null); // ja
+            vedtak.setEropprinneligvedtak("nei");
+            vedtak.setErendringsvedtak("nei");
             vedtak.setDatoforrigevedtak(
-                    vedtakDto.getDatoForrigeVedtak() != null ? vedtakDto.getDatoForrigeVedtak().toString() : null
+                vedtakDto.getDatoForrigeVedtak() != null ? vedtakDto.getDatoForrigeVedtak().toString() : null
             );
         } else {
             vedtak.setEropprinneligvedtak("ja");
-            vedtak.setErendringsvedtak("nei");
+            vedtak.setErendringsvedtak("ja");
         }
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003MapperTest.java
@@ -54,8 +54,7 @@ class A003MapperTest {
         MedlemskapA003 medlemskapA003 = (MedlemskapA003) sed.getMedlemskap();
 
         assertThat(medlemskapA003).isNotNull();
-        assertThat(medlemskapA003.getVedtak().getEropprinneligvedtak()).isNull(); // null betyr Nei
-        assertThat(medlemskapA003.getVedtak().getErendringsvedtak()).isNull(); // null betyr Ja
+        assertThat(medlemskapA003.getVedtak().getEropprinneligvedtak()).isEqualTo("nei");
         assertThat(medlemskapA003.getVedtak().getDatoforrigevedtak()).isNotNull();
         assertThat(medlemskapA003.getVedtak().getDatoforrigevedtak()).isEqualTo(LocalDate.now().toString());
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
@@ -73,8 +73,7 @@ class A009MapperTest {
         MedlemskapA009 medlemskapA009 = (MedlemskapA009) sed.getMedlemskap();
 
         assertThat(medlemskapA009).isNotNull();
-        assertThat(medlemskapA009.getVedtak().getEropprinneligvedtak()).isNull(); // null betyr Nei
-        assertThat(medlemskapA009.getVedtak().getErendringsvedtak()).isNull(); // null betyr Ja
+        assertThat(medlemskapA009.getVedtak().getEropprinneligvedtak()).isEqualTo("nei");
         assertThat(medlemskapA009.getVedtak().getDatoforrigevedtak()).isEqualTo(LocalDate.now().toString());
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
@@ -88,8 +88,7 @@ class A010MapperTest {
         MedlemskapA010 medlemskapA010 = (MedlemskapA010) sed.getMedlemskap();
 
         assertThat(medlemskapA010).isNotNull();
-        assertThat(medlemskapA010.getVedtak().getEropprinneligvedtak()).isNull(); // null betyr Nei
-        assertThat(medlemskapA010.getVedtak().getErendringsvedtak()).isNull(); // null betyr Ja
+        assertThat(medlemskapA010.getVedtak().getEropprinneligvedtak()).isEqualTo("nei");
         assertThat(medlemskapA010.getVedtak().getDatoforrigevedtak()).isEqualTo(LocalDate.now().toString());
     }
 


### PR DESCRIPTION
Har endret tilbake utgående SED vedtak data som ble rettet basert på hva Rina aksepterer. Det ser ut som at noe annet også bruker utgående data, som har foresaket feil, blanet annet bygges PDFen feil (Registrert i MELOSYS-5570) som følge av det

Sak som ble opprettet på buggen https://jira.adeo.no/browse/MELOSYS-5570