### PR TITLE
Mer robust parsing av dato

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerProducer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumerProducer.java
@@ -2,6 +2,7 @@ package no.nav.melosys.eessi.integration.eux.rina_api;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import no.nav.melosys.eessi.integration.interceptor.CorrelationIdOutgoingInterceptor;
 import no.nav.melosys.eessi.security.SystemContextClientRequestInterceptor;
 import no.nav.melosys.eessi.security.UserContextClientRequestInterceptor;
@@ -66,6 +67,7 @@ public class EuxConsumerProducer {
                 .findFirst().ifPresent(jacksonConverer ->
                         jacksonConverer.getObjectMapper()
                                 .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
+                                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
                 );
 
         return restTemplate;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.java
@@ -19,9 +19,7 @@ import no.nav.melosys.eessi.models.SedType;
 public class BUC {
 
     private String id;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     private ZonedDateTime startDate;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     private ZonedDateTime lastUpdate;
     private String status;
     private Creator creator;

--- a/melosys-eessi-app/src/test/resources/mock/buc.json
+++ b/melosys-eessi-app/src/test/resources/mock/buc.json
@@ -1,7 +1,7 @@
 {
   "id": "100485",
   "hashCode": 0,
-  "startDate": "2019-08-29T12:40:35.017+0000",
+  "startDate": "2019-08-29T12:40:35.017+00:00",
   "lastUpdate": "2019-08-29T13:14:40.028+0000",
   "status": "open",
   "subject": null,

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <logback-classic.version>1.2.3</logback-classic.version>
         <logstash-encoder.version>5.3</logstash-encoder.version>
         <lombok.version>1.18.22</lombok.version>
-        <jackson.version>2.12.3</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>


### PR DESCRIPTION
Oppgrade jackson for å støtte med og uten kolon i tidsonen, samt bruk WRITE_DATES_AS_TIMESTAMPS konfiguring av ObjectMapper
https://nav-it.slack.com/archives/CCKCDM0AU/p1671543502995309?thread_ts=1671512526.090249&cid=CCKCDM0AU