### PR TITLE
Bruk ShortenedThrowableConverter for å redusere stacktrace

### DIFF
--- a/melosys-eessi-app/src/main/resources/logback-nais.xml
+++ b/melosys-eessi-app/src/main/resources/logback-nais.xml
@@ -4,7 +4,16 @@
     <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <fieldNames><version>[ignore]</version></fieldNames>
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <exclude>java\.util\.concurrent\..*</exclude>
+                <exclude>org\.apache\.tomcat\..*</exclude>
+                <exclude>org\.apache\.coyote\..*</exclude>
+                <exclude>org\.apache\.catalina\..*</exclude>
+                <exclude>org\.springframework\.web\..*</exclude>
+            </throwableConverter>
         </encoder>
+
     </appender>
 
     <root level="INFO">


### PR DESCRIPTION
For å unngå at vi får delete log meldinger i kibana som da ikke blir rikitg indeksert https://docs.nais.io/observability/logs/examples/
https://jira.adeo.no/browse/MELOSYS-5603