### PR TITLE
5761 Stans X-Sed kun ved utvlagte

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/SedHendelse.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/SedHendelse.java
@@ -4,11 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import no.nav.melosys.eessi.models.SedType;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Builder
 public class SedHendelse {
+    private static final List<String> TRENGER_KONTROLL = Stream.of(SedType.X001, SedType.X006, SedType.X007, SedType.X008).map(Enum::name).toList();
     private long id;
     private String sedId;
     private String sektorKode;
@@ -36,8 +40,8 @@ public class SedHendelse {
     }
 
     @JsonIgnore
-    public boolean erXSed(){
-        return sedType.toUpperCase().startsWith("X");
+    public boolean erXSedSomTrengerKontroll() {
+        return TRENGER_KONTROLL.contains(sedType.toUpperCase());
     }
 
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.java
@@ -46,8 +46,9 @@ public class SedMottakService {
             return;
         }
 
-        if (unleash.isEnabled("melosys.eessi.sed.rekkefolge") && erXSedBehandletUtenASed(sedMottattHendelse.getSedHendelse())) {
-            throw new IllegalStateException("Mottatt SED %s av type %s har ikke tilhørende A sed behandlet".formatted(sedMottattHendelse.getSedHendelse().getSedId(), sedMottattHendelse.getSedHendelse().getSedType()));
+        if (erXSedBehandletUtenASed(sedMottattHendelse.getSedHendelse())) {
+            throw new IllegalStateException("Mottatt SED %s av type %s har ikke tilhørende A sed behandlet"
+                .formatted(sedMottattHendelse.getSedHendelse().getSedId(), sedMottattHendelse.getSedHendelse().getSedType()));
         }
 
         var lagretHendelse = sedMottattHendelseRepository.save(sedMottattHendelse);
@@ -64,7 +65,10 @@ public class SedMottakService {
     }
 
     private boolean erXSedBehandletUtenASed(SedHendelse sedHendelse) {
-        return sedHendelse.erXSed() && !journalpostSedKoblingService.erASedAlleredeBehandlet(sedHendelse.getRinaSakId());
+        if (!unleash.isEnabled("melosys.eessi.sed.rekkefolge")) return false;
+        if (!sedHendelse.erXSedSomTrengerKontroll()) return false;
+
+        return !journalpostSedKoblingService.erASedAlleredeBehandlet(sedHendelse.getRinaSakId());
     }
 
     private void opprettOppgaveIdentifisering(SedMottattHendelse sedMottatt) {


### PR DESCRIPTION
Når vi mottar en X-SED i kafkakøen av typen:
SED_X007
SED_X001
SED_X006
SED_X008
skal vi ikke behandle denne uten at vi har mottatt en A-SED først i samme BUC.