### PR TITLE
5858: Legg til metrikker for Kafka DLQ

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/DLQMetrikkerBinder.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/DLQMetrikkerBinder.java
@@ -1,0 +1,25 @@
+package no.nav.melosys.eessi.metrikker;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import lombok.RequiredArgsConstructor;
+import no.nav.melosys.eessi.models.kafkadlq.QueueType;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DLQMetrikkerBinder implements MeterBinder {
+
+    private final DLQMetrikkerCache dlqMetrikkerCache;
+
+    @Override
+    public void bindTo(@NotNull MeterRegistry meterRegistry) {
+        for (QueueType queueType : QueueType.values()) {
+            Gauge.builder(MetrikkerNavn.KAFKA_DLQ_ANTALL, dlqMetrikkerCache, cache -> cache.getQueueSize(queueType))
+                .tag("queue_type", queueType.name())
+                .register(meterRegistry);
+        }
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/DLQMetrikkerCache.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/DLQMetrikkerCache.java
@@ -1,0 +1,36 @@
+package no.nav.melosys.eessi.metrikker;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.melosys.eessi.models.kafkadlq.QueueType;
+import no.nav.melosys.eessi.models.metrikker.KafkaDLQAntall;
+import no.nav.melosys.eessi.repository.KafkaDLQRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DLQMetrikkerCache {
+
+    private final Map<QueueType, Long> queueSizeMap = new HashMap<>();
+
+    private final KafkaDLQRepository kafkaDLQRepositoy;
+
+    @Scheduled(fixedRate = 10000)
+    public void oppfriskDLQTypeOgAntall() {
+        log.debug("Oppfrisker antalle DLQ per type");
+        List<KafkaDLQAntall> kafkaDLQTypeOgAntall = kafkaDLQRepositoy.countDLQByQueueType();
+        for (KafkaDLQAntall count : kafkaDLQTypeOgAntall) {
+            queueSizeMap.put(count.getQueueType(), count.getAntall());
+        }
+    }
+
+    public double getQueueSize(QueueType queueType) {
+        return queueSizeMap.getOrDefault(queueType, 0L);
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/MetrikkerNavn.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/MetrikkerNavn.java
@@ -4,6 +4,7 @@ public final class MetrikkerNavn {
 
     public static final String METRIKKER_NAMESPACE = "melosys-eessi.";
 
+    static final String KAFKA_DLQ_ANTALL = METRIKKER_NAMESPACE + "kafka.dlq.antall";
     static final String SED_MOTTATT_FEILET_DEPRECATED = METRIKKER_NAMESPACE + "sed.feilet.antall";
     static final String SED_MOTTATT = METRIKKER_NAMESPACE + "sed.mottatt";
     static final String SED_MOTTATT_FEILET = SED_MOTTATT + ".feilet";

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/metrikker/KafkaDLQAntall.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/metrikker/KafkaDLQAntall.java
@@ -1,0 +1,10 @@
+package no.nav.melosys.eessi.models.metrikker;
+
+import no.nav.melosys.eessi.models.kafkadlq.QueueType;
+
+public interface KafkaDLQAntall {
+
+    QueueType getQueueType();
+
+    Long getAntall();
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/KafkaDLQRepository.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/KafkaDLQRepository.java
@@ -1,9 +1,16 @@
 package no.nav.melosys.eessi.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import no.nav.melosys.eessi.models.kafkadlq.KafkaDLQ;
+import no.nav.melosys.eessi.models.metrikker.KafkaDLQAntall;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface KafkaDLQRepository extends JpaRepository<KafkaDLQ, UUID> {
+
+    @Query(value = "SELECT dlq.queue_type as queueType, COUNT(*) as antall FROM kafka_dlq dlq GROUP BY dlq.queue_type",
+        nativeQuery = true)
+    List<KafkaDLQAntall> countDLQByQueueType();
 }


### PR DESCRIPTION
I motsetning til hvordan caching er gjort i API, vil kall til Prometheus aldri utløse databasekall. Her vil man bare hente fra en 10 sekunder gammel cache.

Merk at 
```
  @Scheduled(fixedRate = 10000)
    public void oppfriskDLQTypeOgAntall() {
```
vil bli kalt rett etter at bønnen har blitt opprettet på grunn av defaulverdi initialDelay=-1 i Scheduled. Det skal altså ikke være et tilfelle hvor Prometheus henter feilaktige data. Prometheus henter ikke noe før pod'en er healthy, og da vil man ha refreshet cachen.