### PR TITLE
5963 TOGGLE sende til id og fordeling dersom vi ikke finner folkeregisterident

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollService.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.finn.unleash.Unleash;
 import no.nav.melosys.eessi.integration.PersonFasade;
 import no.nav.melosys.eessi.models.person.PersonModell;
 import no.nav.melosys.eessi.models.person.UtenlandskId;
@@ -24,7 +23,6 @@ public class IdentifiseringKontrollService {
     private final PersonFasade personFasade;
     private final EuxService euxService;
     private final PersonSokMetrikker personSokMetrikker;
-    private final Unleash unleash;
 
     public IdentifiseringsKontrollResultat kontrollerIdentifisertPerson(String aktørId, String rinaSaksnummer, int oppgaveEndretVersjon) {
         var buc = euxService.hentBuc(rinaSaksnummer);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/PersonFasade.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/PersonFasade.java
@@ -11,4 +11,5 @@ public interface PersonFasade {
     String hentAktoerId(String ident);
     String hentNorskIdent(String aktoerID);
     List<PersonSokResponse> soekEtterPerson(PersonsokKriterier personsokKriterier);
+    List<PersonSokResponse> soekEtterPersonGammel(PersonsokKriterier personsokKriterier);
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/journalpostapi/JournalpostapiConfiguration.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/journalpostapi/JournalpostapiConfiguration.java
@@ -3,7 +3,6 @@ package no.nav.melosys.eessi.integration.journalpostapi;
 import java.time.Duration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import no.finn.unleash.Unleash;
 import no.nav.melosys.eessi.integration.interceptor.CorrelationIdOutgoingInterceptor;
 import no.nav.melosys.eessi.security.SystemContextClientRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxTokenContextService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/eux/EuxTokenContextService.java
@@ -1,6 +1,5 @@
 package no.nav.melosys.eessi.service.eux;
 
-import no.finn.unleash.Unleash;
 import no.nav.melosys.eessi.integration.eux.rina_api.EuxConsumer;
 import no.nav.melosys.eessi.metrikker.BucMetrikker;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/joark/JournalpostService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/joark/JournalpostService.java
@@ -1,6 +1,5 @@
 package no.nav.melosys.eessi.service.joark;
 
-import no.finn.unleash.Unleash;
 import no.nav.melosys.eessi.integration.journalpostapi.*;
 import no.nav.melosys.eessi.integration.sak.Sak;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.java
@@ -2,10 +2,8 @@ package no.nav.melosys.eessi.service.mottak;
 
 import javax.transaction.Transactional;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.finn.unleash.Unleash;
 import no.nav.melosys.eessi.identifisering.BucIdentifisertService;
 import no.nav.melosys.eessi.identifisering.PersonIdentifisering;
 import no.nav.melosys.eessi.integration.journalpostapi.SedAlleredeJournalførtException;
@@ -15,7 +13,6 @@ import no.nav.melosys.eessi.models.BucIdentifiseringOppg;
 import no.nav.melosys.eessi.models.SedMottattHendelse;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.buc.BUC;
-import no.nav.melosys.eessi.models.buc.Organisation;
 import no.nav.melosys.eessi.models.buc.Participant;
 import no.nav.melosys.eessi.repository.BucIdentifiseringOppgRepository;
 import no.nav.melosys.eessi.repository.SedMottattHendelseRepository;
@@ -39,7 +36,6 @@ public class SedMottakService {
     private final BucIdentifiseringOppgRepository bucIdentifiseringOppgRepository;
     private final BucIdentifisertService bucIdentifisertService;
     private final JournalpostSedKoblingService journalpostSedKoblingService;
-    private final Unleash unleash;
     private final SedMetrikker sedMetrikker;
 
     @Value("${rina.institusjon-id}")

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/IdentifiseringKontrollServiceTest.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import no.finn.unleash.FakeUnleash;
 import no.nav.melosys.eessi.integration.PersonFasade;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.buc.BUC;
@@ -61,7 +60,7 @@ class IdentifiseringKontrollServiceTest {
 
     @BeforeEach
     void setup() {
-        identifiseringKontrollService = new IdentifiseringKontrollService(personFasade, euxService, personSokMetrikker, new FakeUnleash());
+        identifiseringKontrollService = new IdentifiseringKontrollService(personFasade, euxService, personSokMetrikker);
         var utenlandskPin = new Pin(utenlandskId, avsenderLand, null);
 
         statsborgerskap.setLand(avsenderLand);

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/PersonSokTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/PersonSokTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import com.google.common.collect.Lists;
+import no.finn.unleash.FakeUnleash;
 import no.nav.melosys.eessi.integration.pdl.PDLService;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.person.PersonModell;
@@ -32,11 +33,13 @@ class PersonSokTest {
     @Mock
     private PDLService personFasade;
 
+    private final FakeUnleash unleash = new FakeUnleash();
+
     private PersonSok personSok;
 
     @BeforeEach
     public void setup() throws Exception {
-        personSok = new PersonSok(personFasade);
+        personSok = new PersonSok(personFasade, unleash);
     }
 
     private PersonSokResponse lagPersonSøkResponse() {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/PersonSokTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/identifisering/PersonSokTest.java
@@ -39,6 +39,7 @@ class PersonSokTest {
 
     @BeforeEach
     public void setup() throws Exception {
+        unleash.enableAll();
         personSok = new PersonSok(personFasade, unleash);
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/journalpostapi/JournalpostapiConsumerTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/journalpostapi/JournalpostapiConsumerTest.java
@@ -2,7 +2,6 @@ package no.nav.melosys.eessi.integration.journalpostapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.benas.randombeans.api.EnhancedRandom;
-import no.finn.unleash.FakeUnleash;
 import no.nav.melosys.eessi.EnhancedRandomCreator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,6 @@ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.*;

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/JournalpostServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/joark/JournalpostServiceTest.java
@@ -5,8 +5,6 @@ import java.util.Collections;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.benas.randombeans.api.EnhancedRandom;
-import no.finn.unleash.FakeUnleash;
-import no.finn.unleash.Unleash;
 import no.nav.melosys.eessi.EnhancedRandomCreator;
 import no.nav.melosys.eessi.integration.journalpostapi.JournalpostapiConsumer;
 import no.nav.melosys.eessi.integration.journalpostapi.OpprettJournalpostRequest;

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/mottak/SedMottakServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/mottak/SedMottakServiceTest.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import no.finn.unleash.FakeUnleash;
 import no.nav.melosys.eessi.identifisering.BucIdentifisertService;
 import no.nav.melosys.eessi.identifisering.PersonIdentifisering;
 import no.nav.melosys.eessi.integration.oppgave.HentOppgaveDto;
@@ -62,15 +61,13 @@ class SedMottakServiceTest {
     private static final String SED_ID = "555554444";
     private static final String RINA_SAKSNUMMER = "12313213";
 
-    private FakeUnleash unleash = new FakeUnleash();
-
     @BeforeEach
     public void setup() throws Exception {
         sedMottakService = new SedMottakService(
             euxService, personIdentifisering, opprettInngaaendeJournalpostService,
             oppgaveService, sedMottattHendelseRepository,
             bucIdentifiseringOppgRepository, bucIdentifisertService, journalpostSedKoblingService,
-            unleash, sedMetrikker
+            sedMetrikker
         );
     }
 


### PR DESCRIPTION
Får ikke reprodusert akseptansekriterie: 
```
2) Når vi mottar en BUC i RINA der melosys-eessi ikke klarer å hente DNR eller FNR fra PDL, men vi kun får NPID
og personen både er registrert med NPID og DNR/FNR
Så skal melosys-eessi opprette en journalføringsoppgave som overføres til ID-og fordeling(4303) for identifisering. 
```
og det er allerede en test som viser at det går fint å få både NPID og DNR/FNR fra PDL, men `men vi kun får NPID` er sannsynlig det vi får fra PDL og da kan man se på det som samme scenario som akseptansekriterie 1.

https://jira.adeo.no/browse/MELOSYS-5963