### PR TITLE
VAKT Feil i grafana-gauge pga manglende clearing av map

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/DLQMetrikkerCache.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/metrikker/DLQMetrikkerCache.java
@@ -24,6 +24,7 @@ public class DLQMetrikkerCache {
     @Scheduled(fixedRate = 30000)
     public void oppfriskDLQTypeOgAntall() {
         log.debug("Oppfrisker antall DLQ per type");
+        queueSizeMap.clear();
         List<KafkaDLQAntall> kafkaDLQTypeOgAntall = kafkaDLQRepositoy.countDLQByQueueType();
         for (KafkaDLQAntall count : kafkaDLQTypeOgAntall) {
             queueSizeMap.put(count.getQueueType(), count.getAntall());


### PR DESCRIPTION
Vi resetter ikke queueSizeMap som gjør at gaugen ikke resettes konsekvent for alle typer queueTypes