### PR TITLE
6038 Ukjent  ISO-3 skal gi ukjent ISO-2 landkode

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -1,30 +1,25 @@
 package no.nav.melosys.eessi.service.sed.helpers;
 
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Optional;
+import java.util.*;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.melosys.eessi.models.exception.NotFoundException;
 
 @Slf4j
 public final class LandkodeMapper {
 
     private LandkodeMapper() {}
 
-    private static final BiMap<String, String> ISO3_ISO2_LANDKODER_MAP = HashBiMap.create();
+    private static final Map<String, String> ISO3_TIL_ISO2_LANDKODER_MAP = new HashMap<>();
 
     static {
-        Arrays.stream(Locale.getISOCountries()).forEach(c -> ISO3_ISO2_LANDKODER_MAP.put(new Locale("", c).getISO3Country(), c));
-        ISO3_ISO2_LANDKODER_MAP.put("XXX", "XS"); //Statsløs
-        ISO3_ISO2_LANDKODER_MAP.put("???", "???"); //Ukjent
-        ISO3_ISO2_LANDKODER_MAP.put("XUK", "XUK"); //Ukjent
+        Arrays.stream(Locale.getISOCountries()).forEach(c -> ISO3_TIL_ISO2_LANDKODER_MAP.put(new Locale("", c).getISO3Country(), c));
+        ISO3_TIL_ISO2_LANDKODER_MAP.put("XXX", "XS"); //Statsløs
+        ISO3_TIL_ISO2_LANDKODER_MAP.put("???", "???"); //Ukjent
+        ISO3_TIL_ISO2_LANDKODER_MAP.put("XUK", "???"); //Ukjent
     }
 
     public static String mapTilLandkodeIso2(String landkodeIso3) {
-        return finnLandkodeIso2(landkodeIso3).orElseThrow(() -> new NotFoundException("Landkode " + landkodeIso3 + " ble ikke funnet."));
+        return finnLandkodeIso2(landkodeIso3).orElse("???");
     }
 
     public static Optional<String> finnLandkodeIso2(String landkodeIso3) {
@@ -36,7 +31,7 @@ public final class LandkodeMapper {
             return Optional.of(landkodeIso3);
         }
 
-        return Optional.ofNullable(ISO3_ISO2_LANDKODER_MAP.get(landkodeIso3));
+        return Optional.ofNullable(ISO3_TIL_ISO2_LANDKODER_MAP.get(landkodeIso3));
     }
 
     public static String mapTilNavLandkode(String landkode) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
@@ -25,16 +25,14 @@ class LandkodeMapperTest {
     }
 
     @Test
-    void getIso3_expectNotFoundException() {
-        assertThatExceptionOfType(NotFoundException.class)
-                .isThrownBy(() -> LandkodeMapper.mapTilLandkodeIso2("ABC"))
-                .withMessageContaining("ikke funnet");
+    void getIso3_ikkeFunnet_girUkjent() {
+        assertThat(LandkodeMapper.mapTilLandkodeIso2("ABC")).isEqualTo("???");
     }
 
     @Test
     void getIso2_medIkkeISOStandardKoder_forventSammeKodeTilbake() {
         assertThat(LandkodeMapper.mapTilLandkodeIso2("???")).isEqualTo("???");
         assertThat(LandkodeMapper.mapTilLandkodeIso2("XXX")).isEqualTo("XS");
-        assertThat(LandkodeMapper.mapTilLandkodeIso2("XUK")).isEqualTo("XUK");
+        assertThat(LandkodeMapper.mapTilLandkodeIso2("XUK")).isEqualTo("???");
     }
 }


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6038
Ingen grunn til å feile med exception her. Fjern også unødvendig bruk av BiMap
