### PR TITLE
VAKT: Kall transactional-metode fra utsiden av klassen

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/SedMottattAdminTjeneste.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/SedMottattAdminTjeneste.java
@@ -50,11 +50,9 @@ public class SedMottattAdminTjeneste {
         log.info("Sed mottatt fra SedMottattAdminTjeneste : {}", sedHendelse);
 
         try {
-            sedMottakService.behandleSed(SedMottattHendelse.builder()
+            sedMottakService.behandleSedMottakHendelse(SedMottattHendelse.builder()
                 .sedHendelse(sedHendelse)
                 .build());
-
-            sedMetrikker.sedMottatt(sedHendelse.getSedType());
         } catch (SedAlleredeJournalførtException e) {
             log.warn("SED {} allerede journalført", e.getSedID());
             sedMetrikker.sedMottattAlleredejournalfoert(sedHendelse.getSedType());

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.identifisering.OppgaveEndretHendelseGammel;
 import no.nav.melosys.eessi.identifisering.OppgaveKafkaAivenRecord;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
+import no.nav.melosys.eessi.models.SedMottattHendelse;
 import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.kafkadlq.*;
 import no.nav.melosys.eessi.repository.KafkaDLQRepository;
@@ -125,9 +126,10 @@ public class KafkaDLQService {
         putToMDC(SED_ID, sedHendelse.getSedId());
         putToMDC(CORRELATION_ID, UUID.randomUUID().toString());
         log.info("Mottatt melding om sed mottatt: {}, uuid: {}", sedHendelse, sedMottattHendelseKafkaDLQ.getId());
-
         try {
-            sedMottakService.behandleSedMottakHendelse(sedHendelse);
+            sedMottakService.behandleSedMottakHendelse(SedMottattHendelse.builder()
+                .sedHendelse(sedHendelse)
+                .build());
             kafkaDLQRepository.delete(sedMottattHendelseKafkaDLQ);
         } catch (Exception e) {
             sedMottattHendelseKafkaDLQ.setTidSistRekjort(LocalDateTime.now());

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kontroll/SedMottakAdminTjeneste.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kontroll/SedMottakAdminTjeneste.java
@@ -78,7 +78,7 @@ public class SedMottakAdminTjeneste {
 
     private void restartAlleFeiledeSEDer(Collection<SedMottattHendelse> sedmottattHendelser) {
         sedmottattHendelser
-            .forEach(sedMottakService::behandleSed);
+            .forEach(sedMottakService::behandleSedMottakHendelse);
     }
 
     private void validerApikey(String value) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/kontroll/SedMottakAdminTjenesteTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/kontroll/SedMottakAdminTjenesteTest.java
@@ -72,12 +72,12 @@ class SedMottakAdminTjenesteTest {
 
         when(sedMottattHendelseRepository.findAllByJournalpostIdIsNullOrderByMottattDato())
             .thenReturn(singletonList(sedMottattHendelse));
-        doNothing().when(sedMottakService).behandleSed(valueCapture.capture());
+        doNothing().when(sedMottakService).behandleSedMottakHendelse(valueCapture.capture());
 
         sedMottakAdminTjeneste.restartAlleSEDerUtenJournalpostId(apiKey);
 
         assertThat(valueCapture.getValue()).isEqualTo(sedMottattHendelse);
-        verify(sedMottakService, times(1)).behandleSed(any(SedMottattHendelse.class));
+        verify(sedMottakService, times(1)).behandleSedMottakHendelse(any(SedMottattHendelse.class));
 
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/mottak/SedMottakServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/mottak/SedMottakServiceTest.java
@@ -85,7 +85,7 @@ class SedMottakServiceTest {
         SedMottattHendelse sedMottattHendelse = SedMottattHendelse.builder().sedHendelse(sedHendelse).build();
 
 
-        sedMottakService.behandleSed(sedMottattHendelse);
+        sedMottakService.behandleSedMottakHendelse(sedMottattHendelse);
 
 
         verify(euxService).hentSedMedRetry(anyString(), anyString());
@@ -105,7 +105,7 @@ class SedMottakServiceTest {
         SedHendelse sedHendelse = sedHendelseMedBruker();
 
 
-        sedMottakService.behandleSed(SedMottattHendelse.builder().sedHendelse(sedHendelse).build());
+        sedMottakService.behandleSedMottakHendelse(SedMottattHendelse.builder().sedHendelse(sedHendelse).build());
 
 
         verify(euxService).hentSedMedRetry(anyString(), anyString());
@@ -131,7 +131,7 @@ class SedMottakServiceTest {
         SedHendelse sedHendelse = sedHendelseMedBruker();
 
 
-        sedMottakService.behandleSed(SedMottattHendelse.builder().sedHendelse(sedHendelse).build());
+        sedMottakService.behandleSedMottakHendelse(SedMottattHendelse.builder().sedHendelse(sedHendelse).build());
 
 
         verify(opprettInngaaendeJournalpostService, never()).arkiverInngaaendeSedUtenBruker(any(), any(), any());
@@ -145,7 +145,7 @@ class SedMottakServiceTest {
         when(sedMottattHendelseRepository.findBySedID(SED_ID)).thenReturn(Optional.of(sedMottattHendelse));
 
 
-        sedMottakService.behandleSed(sedMottattHendelse);
+        sedMottakService.behandleSedMottakHendelse(sedMottattHendelse);
 
 
         verify(euxService, never()).hentSedMedRetry(anyString(), anyString());
@@ -163,7 +163,7 @@ class SedMottakServiceTest {
         when(journalpostSedKoblingService.erASedAlleredeBehandlet(anyString())).thenReturn(false);
 
 
-        assertThatThrownBy(() -> sedMottakService.behandleSed(sedMottattHendelse))
+        assertThatThrownBy(() -> sedMottakService.behandleSedMottakHendelse(sedMottattHendelse))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Mottatt SED 555554444 av type X008 har ikke tilhørende A sed behandlet");
     }


### PR DESCRIPTION
https://nav-it.slack.com/archives/CPSMP2GKT/p1692014324439299

Det var en rekke SED som hadde feilet ved mottak, men blitt tatt vare på i databasen likevel. Mistenker det er pga Transactional har blitt brukt feil. Når man kaller på en Transactional-metode i samme klasse, fungerer da Transactional ikke fordi man ikke har proxy-klasse i selve klassen. 

Kaller nå Transactional-metoden fra utsiden av klassen.