### PR TITLE
5962: Legg til bedre filter i konfigurasjonen til konsumering av Aiven topic OppgaveHendelse

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/KafkaAivenConfig.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/KafkaAivenConfig.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.identifisering.OppgaveKafkaAivenRecord;
 import no.nav.melosys.eessi.kafka.consumers.SedHendelse;
+import no.nav.melosys.eessi.service.oppgave.OppgaveEndretService;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -47,6 +48,9 @@ public class KafkaAivenConfig {
 
     @Autowired
     private Environment env;
+
+    @Autowired
+    OppgaveEndretService oppgaveEndretService;
 
     @Value("${melosys.kafka.aiven.brokers}")
     private String brokersUrl;
@@ -189,6 +193,9 @@ public class KafkaAivenConfig {
     }
 
     private RecordFilterStrategy<String, OppgaveKafkaAivenRecord> recordFilterStrategyOppgaveHendelserListener() {
-        return consumerRecord -> !OPPGAVE_ENDRET.equals(consumerRecord.value().hendelse().hendelsestype());
+        return consumerRecord -> (
+            !OPPGAVE_ENDRET.equals(consumerRecord.value().hendelse().hendelsestype())
+                && !oppgaveEndretService.erValidertIdentifiseringsoppgave(consumerRecord.value()))
+            ;
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/KafkaAivenConfig.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/KafkaAivenConfig.java
@@ -195,7 +195,7 @@ public class KafkaAivenConfig {
     private RecordFilterStrategy<String, OppgaveKafkaAivenRecord> recordFilterStrategyOppgaveHendelserListener() {
         return consumerRecord -> (
             !OPPGAVE_ENDRET.equals(consumerRecord.value().hendelse().hendelsestype())
-                && !oppgaveEndretService.erValidertIdentifiseringsoppgave(consumerRecord.value()))
+                && !oppgaveEndretService.erIdentifiseringsOppgave(consumerRecord.value()))
             ;
     }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/oppgave/OppgaveEndretService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/oppgave/OppgaveEndretService.java
@@ -38,7 +38,7 @@ public class OppgaveEndretService {
     }
 
 
-    public boolean erValidertIdentifiseringsoppgave(OppgaveKafkaAivenRecord oppgaveEndretHendelse) {
+    private boolean erValidertIdentifiseringsoppgave(OppgaveKafkaAivenRecord oppgaveEndretHendelse) {
         return erIdentifiseringsOppgave(oppgaveEndretHendelse) && validerOppgaveStatusOgVersjon(oppgaveEndretHendelse);
     }
 
@@ -58,7 +58,7 @@ public class OppgaveEndretService {
         return true;
     }
 
-    private boolean erIdentifiseringsOppgave(OppgaveKafkaAivenRecord oppgaveEndretHendelse) {
+    public boolean erIdentifiseringsOppgave(OppgaveKafkaAivenRecord oppgaveEndretHendelse) {
         return "JFR".equals(oppgaveEndretHendelse.oppgave().kategorisering().oppgavetype())
             && "4530".equals(oppgaveEndretHendelse.oppgave().tilordning().enhetsnr())
             && oppgaveEndretHendelse.harFolkeregisterIdent()

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/oppgave/OppgaveEndretService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/oppgave/OppgaveEndretService.java
@@ -38,7 +38,7 @@ public class OppgaveEndretService {
     }
 
 
-    private boolean erValidertIdentifiseringsoppgave(OppgaveKafkaAivenRecord oppgaveEndretHendelse) {
+    public boolean erValidertIdentifiseringsoppgave(OppgaveKafkaAivenRecord oppgaveEndretHendelse) {
         return erIdentifiseringsOppgave(oppgaveEndretHendelse) && validerOppgaveStatusOgVersjon(oppgaveEndretHendelse);
     }
 


### PR DESCRIPTION
https://github.com/navikt/melosys-eessi/pull/563
Etter å ha satt loggnivå til INFO, og prodsatt, så ser jeg det kommer utrolig mye oppgavehendelse-endringer. Det betyr at det blir gjort litt flere oppgaveendringer enn først tenkt. Slik det er nå, så ignorerer vi visse typer oppgaveendringer når vi først prøver å konsumere meldingen. Siden vi har spesifikke regler på hva vi vil høre på, setter jeg dette på config-nivå, sånn at vi ikke trenger å consumere meldingen i det hele tatt. 