### PR TITLE
5962: Fjern toggle for logging av oppgavehendelser

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/OppgaveHendelseConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/kafka/consumers/OppgaveHendelseConsumer.java
@@ -33,22 +33,20 @@ public class OppgaveHendelseConsumer extends AbstractConsumerSeekAware {
         errorHandler = "oppgaveEndretErrorHandler"
     )
     public void oppgaveHendelse(ConsumerRecord<String, OppgaveKafkaAivenRecord> consumerRecord) {
-            final var oppgaveEndretHendelse = consumerRecord.value();
-            if (unleash.isEnabled("melosys.eessi.oppgavehandtering_oppgavehendelser_aiven_logg")) {
-                log.info("Mottatt melding om oppgaveHendelse: {}", oppgaveEndretHendelse.oppgave().oppgaveId());
-            }
-            putToMDC(CORRELATION_ID, UUID.randomUUID().toString());
+        final var oppgaveEndretHendelse = consumerRecord.value();
+        log.info("Mottatt melding om oppgaveHendelse: {}", oppgaveEndretHendelse.oppgave().oppgaveId());
+        putToMDC(CORRELATION_ID, UUID.randomUUID().toString());
 
-            try {
-                oppgaveEndretService.behandleOppgaveEndretHendelse(oppgaveEndretHendelse);
-            } catch (Exception e) {
-                String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-                log.error("Klarte ikke å konsumere melding om oppgave endret: {}\n{}", message, consumerRecord, e);
+        try {
+            oppgaveEndretService.behandleOppgaveEndretHendelse(oppgaveEndretHendelse);
+        } catch (Exception e) {
+            String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            log.error("Klarte ikke å konsumere melding om oppgave endret: {}\n{}", message, consumerRecord, e);
 
-                kafkaDLQService.lagreOppgaveEndretHendelse(oppgaveEndretHendelse, e.getMessage());
-            } finally {
-                remove(CORRELATION_ID);
-            }
+            kafkaDLQService.lagreOppgaveEndretHendelse(oppgaveEndretHendelse, e.getMessage());
+        } finally {
+            remove(CORRELATION_ID);
+        }
     }
 
     public void settSpesifiktOffsetPåConsumer(long offset) {


### PR DESCRIPTION
Ref. beskrivelsen her: https://github.com/navikt/melosys-eessi/pull/571
Tidligere (se https://github.com/navikt/melosys-eessi/pull/563) så lagde denne loggingen alt for mye støy, ettersom vi konsumerte _alle_ oppgaveendringer. Det ble omtrent 3k oppgaver vi reagerte på per 15 minutt. https://github.com/navikt/melosys-eessi/pull/564 la på filter på config av konsumenten som gjør at vi kun konsumerer de som vi faktisk skal reagere på.

Jeg har fulgt med på loggene og ser at det filteren vår fungerer ganske bra. Det er altså ikke så mange relevante oppgaveendringer vi konsumerer som gjør at logging lager støy nå. 