### PR TITLE
5930 TOGGLE: Send iso3 landkode til PDL-WEB

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
@@ -36,7 +36,7 @@ public class IdentRekvisisjonTilMellomlagringMapper {
             )
             .kontaktadresse(
                 IdentRekvisisjonKontaktadresse.builder()
-                    .utenlandskPostboksadresse(hentUtenlandskPostAdresse(sed))
+                    .utenlandskVegadresse(hentUtenlandskVegadresse(sed))
                     .build()
             );
 
@@ -52,15 +52,16 @@ public class IdentRekvisisjonTilMellomlagringMapper {
         return identRekvisjonTilMellomlagringBuilder.build();
     }
 
-    private static IdentRekvisisjonUtenlandskPostboksadresse hentUtenlandskPostAdresse(SED sed) {
+    private static IdentRekvisisjonUtenlandskVegadresse hentUtenlandskVegadresse(SED sed) {
         var adresse = sed.getNav().getBruker().getAdresse() != null ? sed.getNav().getBruker().getAdresse().get(0) : null;
         if (adresse != null) {
-            return IdentRekvisisjonUtenlandskPostboksadresse.builder()
+            return IdentRekvisisjonUtenlandskVegadresse.builder()
+                .adressenavnNummer(adresse.getGate())
+                .bygningEtasjeLeilighet(adresse.getBygning())
                 .postkode(adresse.getPostnummer())
                 .bySted(adresse.getBy())
-                .postboksNummerNavn(adresse.getGate())
-                .landkode(adresse.getLand())
                 .regionDistriktOmraade(adresse.getRegion())
+                .landkode(adresse.getLand())
                 .build();
         }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -7,7 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class LandkodeMapper {
 
-    private LandkodeMapper() {}
+    private LandkodeMapper() {
+    }
 
     private static final Map<String, String> ISO3_TIL_ISO2_LANDKODER_MAP = new HashMap<>();
 
@@ -32,6 +33,21 @@ public final class LandkodeMapper {
         }
 
         return Optional.ofNullable(ISO3_TIL_ISO2_LANDKODER_MAP.get(landkodeIso3));
+    }
+
+    public static String finnLandkodeIso3(String landkodeIso2) {
+        if (landkodeIso2 == null) {
+            return null;
+        }
+
+        if (landkodeIso2.length() == 3) {
+            return landkodeIso2;
+        }
+        return ISO3_TIL_ISO2_LANDKODER_MAP.entrySet().stream()
+            .filter(entry -> entry.getValue().equals(landkodeIso2))
+            .map(Map.Entry::getKey)
+            .findFirst()
+            .orElse("???");
     }
 
     public static String mapTilNavLandkode(String landkode) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapperTest.java
@@ -27,7 +27,7 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
         assertEquals("TestFornavn", result.getPersonopplysninger().getFornavn());
         assertEquals("TestEtternavn", result.getPersonopplysninger().getEtternavn());
         assertEquals(LocalDate.of(2000, 1, 1), result.getPersonopplysninger().getFoedselsdato());
-        assertEquals(Set.of("SE", "NO"), result.getPersonopplysninger().getStatsborgerskap());
+        assertEquals(Set.of("SWE", "NOR"), result.getPersonopplysninger().getStatsborgerskap());
         assertEquals("Miami", result.getPersonopplysninger().getFoedested());
         assertEquals("USA", result.getPersonopplysninger().getFoedeland());
     }
@@ -39,7 +39,7 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
         IdentRekvisisjonTilMellomlagring result = IdentRekvisisjonTilMellomlagringMapper.byggIdentRekvisisjonTilMellomlagring(sedMottattHendelse, sed);
 
         assertEquals("SE:123", result.getKilde().getInstitusjon());
-        assertEquals("SE", result.getKilde().getLandkode());
+        assertEquals("SWE", result.getKilde().getLandkode());
     }
 
     @Test
@@ -48,7 +48,7 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
         SedMottattHendelse sedMottattHendelse = createSedHendelse();
         IdentRekvisisjonTilMellomlagring result = IdentRekvisisjonTilMellomlagringMapper.byggIdentRekvisisjonTilMellomlagring(sedMottattHendelse, sed);
 
-        assertEquals("TestLand", result.getKontaktadresse().getUtenlandskVegadresse().getLandkode());
+        assertEquals("NOR", result.getKontaktadresse().getUtenlandskVegadresse().getLandkode());
         assertEquals("TestBy", result.getKontaktadresse().getUtenlandskVegadresse().getBySted());
         assertEquals("TestPostnummer", result.getKontaktadresse().getUtenlandskVegadresse().getPostkode());
         assertEquals("TestRegion", result.getKontaktadresse().getUtenlandskVegadresse().getRegionDistriktOmraade());
@@ -63,7 +63,7 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
         IdentRekvisisjonTilMellomlagring result = IdentRekvisisjonTilMellomlagringMapper.byggIdentRekvisisjonTilMellomlagring(sedMottattHendelse, sed);
 
         assertEquals("12345678911", result.getUtenlandskIdentifikasjon().getUtenlandskId());
-        assertEquals("SE", result.getUtenlandskIdentifikasjon().getUtstederland());
+        assertEquals("SWE", result.getUtenlandskIdentifikasjon().getUtstederland());
     }
 
     @Test
@@ -115,7 +115,7 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
         person.setPin(List.of(new Pin("12345678911", "SE", "sektor")));
         Adresse adresse = new Adresse();
         adresse.setBy("TestBy");
-        adresse.setLand("TestLand");
+        adresse.setLand("NO");
         adresse.setGate("TestGate");
         adresse.setPostnummer("TestPostnummer");
         adresse.setRegion("TestRegion");

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapperTest.java
@@ -48,10 +48,12 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
         SedMottattHendelse sedMottattHendelse = createSedHendelse();
         IdentRekvisisjonTilMellomlagring result = IdentRekvisisjonTilMellomlagringMapper.byggIdentRekvisisjonTilMellomlagring(sedMottattHendelse, sed);
 
-        assertEquals("TestLand", result.getKontaktadresse().getUtenlandskPostboksadresse().getLandkode());
-        assertEquals("TestBy", result.getKontaktadresse().getUtenlandskPostboksadresse().getBySted());
-        assertEquals("TestPostnummer", result.getKontaktadresse().getUtenlandskPostboksadresse().getPostkode());
-        assertEquals("TestRegion", result.getKontaktadresse().getUtenlandskPostboksadresse().getRegionDistriktOmraade());
+        assertEquals("TestLand", result.getKontaktadresse().getUtenlandskVegadresse().getLandkode());
+        assertEquals("TestBy", result.getKontaktadresse().getUtenlandskVegadresse().getBySted());
+        assertEquals("TestPostnummer", result.getKontaktadresse().getUtenlandskVegadresse().getPostkode());
+        assertEquals("TestRegion", result.getKontaktadresse().getUtenlandskVegadresse().getRegionDistriktOmraade());
+        assertEquals("TestGate", result.getKontaktadresse().getUtenlandskVegadresse().getAdressenavnNummer());
+        assertEquals("TestBygning", result.getKontaktadresse().getUtenlandskVegadresse().getBygningEtasjeLeilighet());
     }
 
     @Test
@@ -117,6 +119,7 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
         adresse.setGate("TestGate");
         adresse.setPostnummer("TestPostnummer");
         adresse.setRegion("TestRegion");
+        adresse.setBygning("TestBygning");
         Bruker bruker = new Bruker();
         bruker.setPerson(person);
         bruker.setAdresse(List.of(adresse));

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
@@ -2,7 +2,13 @@ package no.nav.melosys.eessi.service.helpers;
 
 import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -34,5 +40,30 @@ class LandkodeMapperTest {
         assertThat(LandkodeMapper.mapTilLandkodeIso2("???")).isEqualTo("???");
         assertThat(LandkodeMapper.mapTilLandkodeIso2("XXX")).isEqualTo("XS");
         assertThat(LandkodeMapper.mapTilLandkodeIso2("XUK")).isEqualTo("???");
+    }
+
+    @Test
+    public void skalReturnereISO3KodeForGyldigISO2Kode() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("US")).isEqualTo("USA");
+    }
+
+    @Test
+    public void skalReturnereSammeKodeForISO3Kode() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("USA")).isEqualTo("USA");
+    }
+
+    @Test
+    public void skalReturnereUkjentForUgyldigISO2Kode() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("ZZ")).isEqualTo("???");
+    }
+
+    @Test
+    public void skalReturnereNullForNullInndata() {
+        assertThat(LandkodeMapper.finnLandkodeIso3(null)).isEqualTo(null);
+    }
+
+    @Test
+    public void skalReturnereUkjentForTomStreng() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("")).isEqualTo("???");
     }
 }


### PR DESCRIPTION
De klarer ikke å forhåndsvise data vi sender til PDL. Det er fordi vi sender i ISO2-format, mens de forventer i ISO3-format. De ønsker ikke å konvertere selv, og ønsker heller at vi sender riktig data i utgangspunktet.