### PR TITLE
5930 TOGGLE: Send Ukjent landkode til PDL-WEB som XUK og ikke ???

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
@@ -1,16 +1,15 @@
 package no.nav.melosys.eessi.integration.pdl.web.identrekvisisjon.dto;
 
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import no.nav.melosys.eessi.integration.pdl.dto.PDLKjoennType;
 import no.nav.melosys.eessi.models.SedMottattHendelse;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.nav.Kjønn;
 import no.nav.melosys.eessi.models.sed.nav.Person;
 import no.nav.melosys.eessi.models.sed.nav.Statsborgerskap;
-import no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper;
-
-import java.time.LocalDate;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static no.nav.melosys.eessi.service.sed.helpers.LandkodeMapper.finnLandkodeIso3;
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
@@ -24,7 +24,7 @@ public class IdentRekvisisjonTilMellomlagringMapper {
                 IdentRekvisisjonKilde.builder()
                     .institusjon(sedMottattHendelse.getSedHendelse().getAvsenderNavn())
                     .landkode(Objects.requireNonNull(
-                        finnLandkodeIso3(sedMottattHendelse.getSedHendelse().getLandkode())
+                        finnLandkodeIso3(sedMottattHendelse.getSedHendelse().getLandkode(), true)
                         , "Landkode kan ikke være null fra SED"))
                     .build()
             )
@@ -34,13 +34,13 @@ public class IdentRekvisisjonTilMellomlagringMapper {
                     .etternavn(personFraSed.getEtternavn())
                     .foedselsdato(LocalDate.parse(personFraSed.getFoedselsdato()))
                     .kjoenn(hentPDLKjønn(personFraSed))
-                    .foedeland(personFraSed.getFoedested() != null ? finnLandkodeIso3(personFraSed.getFoedested().getLand()) : null)
+                    .foedeland(personFraSed.getFoedested() != null ? finnLandkodeIso3(personFraSed.getFoedested().getLand(), true) : null)
                     .foedested(personFraSed.getFoedested() != null ? personFraSed.getFoedested().getBy() : null)
                     .statsborgerskap(
                         personFraSed.getStatsborgerskap()
                             .stream()
                             .map(Statsborgerskap::getLand)
-                            .map(LandkodeMapper::finnLandkodeIso3)
+                            .map(land -> finnLandkodeIso3(land, true))
                             .collect(Collectors.toSet()))
                     .build()
             )
@@ -55,7 +55,7 @@ public class IdentRekvisisjonTilMellomlagringMapper {
             .ifPresent(pin -> identRekvisjonTilMellomlagringBuilder.utenlandskIdentifikasjon(
                 IdentRekvisisjonUtenlandskIdentifikasjon
                     .builder()
-                    .utstederland(finnLandkodeIso3(pin.getLand()))
+                    .utstederland(finnLandkodeIso3(pin.getLand(), true))
                     .utenlandskId(pin.getIdentifikator())
                     .build()));
 
@@ -71,7 +71,7 @@ public class IdentRekvisisjonTilMellomlagringMapper {
                 .postkode(adresse.getPostnummer())
                 .bySted(adresse.getBy())
                 .regionDistriktOmraade(adresse.getRegion())
-                .landkode(finnLandkodeIso3(adresse.getLand()))
+                .landkode(finnLandkodeIso3(adresse.getLand(), true))
                 .build();
         }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -35,7 +35,7 @@ public final class LandkodeMapper {
         return Optional.ofNullable(ISO3_TIL_ISO2_LANDKODER_MAP.get(landkodeIso3));
     }
 
-    public static String finnLandkodeIso3(String landkodeIso2, boolean ukjentLandkodeForPdl ) {
+    public static String finnLandkodeIso3(String landkodeIso2, boolean ukjentLandkodeMedPdlFormat ) {
         if (landkodeIso2 == null) {
             return null;
         }
@@ -47,7 +47,7 @@ public final class LandkodeMapper {
             .filter(entry -> entry.getValue().equals(landkodeIso2))
             .map(Map.Entry::getKey)
             .findFirst()
-            .orElse(ukjentLandkodeForPdl ? "XUK" : "???");
+            .orElse(ukjentLandkodeMedPdlFormat ? "XUK" : "???");
     }
 
     public static String mapTilNavLandkode(String landkode) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -35,7 +35,7 @@ public final class LandkodeMapper {
         return Optional.ofNullable(ISO3_TIL_ISO2_LANDKODER_MAP.get(landkodeIso3));
     }
 
-    public static String finnLandkodeIso3(String landkodeIso2) {
+    public static String finnLandkodeIso3(String landkodeIso2, boolean ukjentLandkodeForPdl ) {
         if (landkodeIso2 == null) {
             return null;
         }
@@ -47,7 +47,7 @@ public final class LandkodeMapper {
             .filter(entry -> entry.getValue().equals(landkodeIso2))
             .map(Map.Entry::getKey)
             .findFirst()
-            .orElse("???");
+            .orElse(ukjentLandkodeForPdl ? "XUK" : "???");
     }
 
     public static String mapTilNavLandkode(String landkode) {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
@@ -44,26 +44,36 @@ class LandkodeMapperTest {
 
     @Test
     public void skalReturnereISO3KodeForGyldigISO2Kode() {
-        assertThat(LandkodeMapper.finnLandkodeIso3("US")).isEqualTo("USA");
+        assertThat(LandkodeMapper.finnLandkodeIso3("US", true)).isEqualTo("USA");
     }
 
     @Test
     public void skalReturnereSammeKodeForISO3Kode() {
-        assertThat(LandkodeMapper.finnLandkodeIso3("USA")).isEqualTo("USA");
+        assertThat(LandkodeMapper.finnLandkodeIso3("USA", true)).isEqualTo("USA");
     }
 
     @Test
-    public void skalReturnereUkjentForUgyldigISO2Kode() {
-        assertThat(LandkodeMapper.finnLandkodeIso3("ZZ")).isEqualTo("???");
+    public void skalReturnereUkjentForUgyldigISO2KodeFelleskodeverkFormat() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("ZZ", false)).isEqualTo("???");
+    }
+
+    @Test
+    public void skalReturnereUkjentForUgyldigISO2KodePdlFormat() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("ZZ", true)).isEqualTo("XUK");
     }
 
     @Test
     public void skalReturnereNullForNullInndata() {
-        assertThat(LandkodeMapper.finnLandkodeIso3(null)).isEqualTo(null);
+        assertThat(LandkodeMapper.finnLandkodeIso3(null, true)).isEqualTo(null);
     }
 
     @Test
-    public void skalReturnereUkjentForTomStreng() {
-        assertThat(LandkodeMapper.finnLandkodeIso3("")).isEqualTo("???");
+    public void skalReturnereUkjentForTomStrengMedFelleskodeverkFormat() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("", false)).isEqualTo("???");
+    }
+
+    @Test
+    public void skalReturnereUkjentForTomStrengMedPdlFormat() {
+        assertThat(LandkodeMapper.finnLandkodeIso3("", true)).isEqualTo("XUK");
     }
 }


### PR DESCRIPTION
Slik det er i dag: Når land er ukjent (som f.eks. Jugoslavia), så konverterer vi vanligvis til "???" i melosys-eessi før vi får det over til API. Dette er pga felles-kodeverk som har "???" for UKJENT.
Ifm. SED-rekvirering så sender vi en del landkoder til PDL. Disse landkodene forventer PDL at det skal være i ISO3-format. De kjenner ikke til "???" for ukjente land, og opererer istedenfor med XUK. I ISO-3 så er alle koder som starter med X brukerdefinerte. XUK (for "brukerdefinert UKJENT") mener jeg også gir mer mening å ha enn ???.

Sender altså XUK til pdl-web. Akkurat nå er det ingen andre steder som konverterer fra iso2 til iso3, men siden det er en slags global funksjon, lar jeg neste som bruker det velge hvorvidt de skal ha ??? eller XUK.