### PR TITLE
NOJIRA Mapper GB om til UK, og EL om til GR for identrekvisisjon

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/helpers/LandkodeMapper.java
@@ -44,7 +44,7 @@ public final class LandkodeMapper {
             return landkodeIso2;
         }
         return ISO3_TIL_ISO2_LANDKODER_MAP.entrySet().stream()
-            .filter(entry -> entry.getValue().equals(landkodeIso2))
+            .filter(entry -> entry.getValue().equals(mapTilNavLandkode(landkodeIso2)))
             .map(Map.Entry::getKey)
             .findFirst()
             .orElse(skalReturnereNullForUkjent ? null : "XUK");

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/helpers/LandkodeMapperTest.java
@@ -35,37 +35,47 @@ class LandkodeMapperTest {
     }
 
     @Test
-    public void skalReturnereISO3KodeForGyldigISO2Kode() {
+    void skalReturnereISO3KodeForGyldigISO2Kode() {
         assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("US", true)).isEqualTo("USA");
     }
 
     @Test
-    public void skalReturnereSammeKodeForISO3Kode() {
+    void skalReturnereSammeKodeForISO3Kode() {
         assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("USA", true)).isEqualTo("USA");
     }
 
     @Test
-    public void skalReturnereUkjentForUgyldigISO2KodeFelleskodeverkFormat() {
+    void skalReturnereUkjentForUgyldigISO2KodeFelleskodeverkFormat() {
         assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("ZZ", false)).isEqualTo("XUK");
     }
 
     @Test
-    public void skalReturnereUkjentForUgyldigISO2KodePdlFormat() {
+    void skalReturnereUkjentForUgyldigISO2KodePdlFormat() {
         assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("ZZ", true)).isNull();
     }
 
     @Test
-    public void skalReturnereNullForNullInndata() {
-        assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon(null, true)).isEqualTo(null);
+    void skalReturnereNullForNullInndata() {
+        assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon(null, true)).isNull();
     }
 
     @Test
-    public void skalReturnereUkjentForTomStrengMedFelleskodeverkFormat() {
+    void skalReturnereUkjentForTomStrengMedFelleskodeverkFormat() {
         assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("", false)).isEqualTo("XUK");
     }
 
     @Test
-    public void skalReturnereUkjentForTomStrengMedPdlFormat() {
+    void skalReturnereUkjentForTomStrengMedPdlFormat() {
         assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("", false)).isEqualTo("XUK");
+    }
+
+    @Test
+    void skalReturnereGBsinISO3ForUK() {
+        assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("UK", false)).isEqualTo("GBR");
+    }
+
+    @Test
+    void skalReturnereGRsinISO3IForEL() {
+        assertThat(LandkodeMapper.finnLandkodeIso3ForIdentRekvisisjon("EL", false)).isEqualTo("GRC");
     }
 }


### PR DESCRIPTION
Bruker eksisterende funksjon mapTilNavLandkode for å støtte GB og EL:

```
public static String mapTilNavLandkode(String landkode) {
  if ("UK".equalsIgnoreCase(landkode)) {
    return "GB";
  } else if ("EL".equalsIgnoreCase(landkode)) {
    return "GR";
  }
    return landkode;
}
```

https://nav-it.slack.com/archives/CPSMP2GKT/p1700057242620329