### PR TITLE
6293: Fiks feil med null i statsborgerskap ved identrekvisisjon

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapper.java
@@ -38,6 +38,7 @@ public class IdentRekvisisjonTilMellomlagringMapper {
                     .statsborgerskap(
                         personFraSed.getStatsborgerskap()
                             .stream()
+                            .filter(Objects::nonNull)
                             .map(Statsborgerskap::getLand)
                             .map(land -> finnLandkodeIso3ForIdentRekvisisjon(land, false))
                             .collect(Collectors.toSet()))

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/web/identrekvisisjon/dto/IdentRekvisisjonTilMellomlagringMapperTest.java
@@ -23,6 +23,9 @@ class IdentRekvisisjonTilMellomlagringMapperTest {
     @Test
     public void byggIdentRekvisisjonTilMellomlagringSetterRiktigPersonopplysninger() {
         SED sed = lagSED();
+        sed.finnPerson().get().setStatsborgerskap(
+            Arrays.asList(new Statsborgerskap("SWE"), new Statsborgerskap("NOR"), null)
+        );
         SedMottattHendelse sedMottattHendelse = createSedHendelse();
         IdentRekvisisjonTilMellomlagring result = IdentRekvisisjonTilMellomlagringMapper.byggIdentRekvisisjonTilMellomlagring(sedMottattHendelse, sed);
 


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-6293

Filtrerer  bort statsborgerskap i SED som er null ved utfylling av DTO til pdl-web.

