### PR TITLE
6472 Erendringsvedtak justering

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/nav/Vedtak.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/nav/Vedtak.java
@@ -5,6 +5,6 @@ import lombok.Data;
 @Data
 public abstract class Vedtak {
     private String datoforrigevedtak;
-    private String eropprinneligvedtak; // RINA regler: Kan bare sette "ja" eller null (default: null, som betyr nei)
-    private String erendringsvedtak; // RINA regler: Kan bare sette "nei" eller null (default: null, som betyr ja)
+    private String eropprinneligvedtak;
+    private String erendringsvedtak;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/nav/Vedtak.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/sed/nav/Vedtak.java
@@ -5,6 +5,6 @@ import lombok.Data;
 @Data
 public abstract class Vedtak {
     private String datoforrigevedtak;
-    private String eropprinneligvedtak;
-    private String erendringsvedtak;
+    private String eropprinneligvedtak; // RINA regler: Kan bare sette "ja" eller null (default: null, som betyr nei)
+    private String erendringsvedtak; // RINA regler: Kan bare sette "nei" eller null (default: null, som betyr ja)
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
@@ -22,7 +22,8 @@ public interface LovvalgSedMapper<T extends Medlemskap> extends SedMapper {
 
     default void setVedtaksdata(Vedtak vedtak, VedtakDto vedtakDto) {
         if (vedtakDto != null && !vedtakDto.isErFørstegangsvedtak()) {
-            vedtak.setErendringsvedtak("ja");
+            vedtak.setEropprinneligvedtak(null);
+            vedtak.setErendringsvedtak(null);
             vedtak.setDatoforrigevedtak(
                 vedtakDto.getDatoForrigeVedtak() != null ? vedtakDto.getDatoForrigeVedtak().toString() : null
             );

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
@@ -23,7 +23,7 @@ public interface LovvalgSedMapper<T extends Medlemskap> extends SedMapper {
     default void setVedtaksdata(Vedtak vedtak, VedtakDto vedtakDto) {
         if (vedtakDto != null && !vedtakDto.isErFørstegangsvedtak()) {
             vedtak.setEropprinneligvedtak(null);
-            vedtak.setErendringsvedtak(null);
+            vedtak.setErendringsvedtak("nei");
             vedtak.setDatoforrigevedtak(
                 vedtakDto.getDatoForrigeVedtak() != null ? vedtakDto.getDatoForrigeVedtak().toString() : null
             );

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
@@ -22,14 +22,12 @@ public interface LovvalgSedMapper<T extends Medlemskap> extends SedMapper {
 
     default void setVedtaksdata(Vedtak vedtak, VedtakDto vedtakDto) {
         if (vedtakDto != null && !vedtakDto.isErFørstegangsvedtak()) {
-            vedtak.setEropprinneligvedtak("nei");
             vedtak.setErendringsvedtak("ja");
             vedtak.setDatoforrigevedtak(
                 vedtakDto.getDatoForrigeVedtak() != null ? vedtakDto.getDatoForrigeVedtak().toString() : null
             );
         } else {
             vedtak.setEropprinneligvedtak("ja");
-            vedtak.setErendringsvedtak("nei");
         }
     }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
@@ -22,7 +22,6 @@ public interface LovvalgSedMapper<T extends Medlemskap> extends SedMapper {
 
     default void setVedtaksdata(Vedtak vedtak, VedtakDto vedtakDto) {
         if (vedtakDto != null && !vedtakDto.isErFørstegangsvedtak()) {
-            vedtak.setEropprinneligvedtak(null);
             vedtak.setErendringsvedtak("nei");
             vedtak.setDatoforrigevedtak(
                 vedtakDto.getDatoForrigeVedtak() != null ? vedtakDto.getDatoForrigeVedtak().toString() : null

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/LovvalgSedMapper.java
@@ -23,13 +23,13 @@ public interface LovvalgSedMapper<T extends Medlemskap> extends SedMapper {
     default void setVedtaksdata(Vedtak vedtak, VedtakDto vedtakDto) {
         if (vedtakDto != null && !vedtakDto.isErFørstegangsvedtak()) {
             vedtak.setEropprinneligvedtak("nei");
-            vedtak.setErendringsvedtak("nei");
+            vedtak.setErendringsvedtak("ja");
             vedtak.setDatoforrigevedtak(
                 vedtakDto.getDatoForrigeVedtak() != null ? vedtakDto.getDatoForrigeVedtak().toString() : null
             );
         } else {
             vedtak.setEropprinneligvedtak("ja");
-            vedtak.setErendringsvedtak("ja");
+            vedtak.setErendringsvedtak("nei");
         }
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A003MapperTest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 
-
 import no.nav.melosys.eessi.controller.dto.SedDataDto;
 import no.nav.melosys.eessi.controller.dto.VedtakDto;
 import no.nav.melosys.eessi.models.exception.MappingException;
@@ -12,8 +11,8 @@ import no.nav.melosys.eessi.models.exception.NotFoundException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA003;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +29,7 @@ class A003MapperTest {
     }
 
     @Test
-    void mapTilSed() throws IOException, URISyntaxException, MappingException, NotFoundException {
+    void mapTilSed() throws MappingException, NotFoundException {
         SED sed = sedMapper.mapTilSed(sedData);
 
         assertThat(sed).isNotNull();
@@ -42,20 +41,38 @@ class A003MapperTest {
     }
 
     @Test
-    void erIkkeOpprinneligVedtak_ErOpprinneligVedtaksNeiOgDatoForrigeVedtakIkkeNull() {
+    void erIkkeOpprinneligVedtak_ErOpprinneligVedtakOgErEndringsvedtakSattKorrektOgDatoForrigeVedtakIkkeNull() {
         VedtakDto vedtakDto = new VedtakDto();
         vedtakDto.setErFørstegangsvedtak(false);
         vedtakDto.setDatoForrigeVedtak(LocalDate.now());
         sedData.setVedtakDto(vedtakDto);
+
+
         SED sed = sedMapper.mapTilSed(sedData);
 
         assertThat(sed.getMedlemskap().getClass()).isEqualTo(MedlemskapA003.class);
-
         MedlemskapA003 medlemskapA003 = (MedlemskapA003) sed.getMedlemskap();
-
         assertThat(medlemskapA003).isNotNull();
-        assertThat(medlemskapA003.getVedtak().getEropprinneligvedtak()).isEqualTo("nei");
+        assertThat(medlemskapA003.getVedtak().getEropprinneligvedtak()).isNull();
+        assertThat(medlemskapA003.getVedtak().getErendringsvedtak()).isEqualTo("nei");
         assertThat(medlemskapA003.getVedtak().getDatoforrigevedtak()).isNotNull();
         assertThat(medlemskapA003.getVedtak().getDatoforrigevedtak()).isEqualTo(LocalDate.now().toString());
+    }
+
+    @Test
+    void erOpprinneligVedtak_ErOpprinneligVedtakOgErEndringsvedtakSattKorrektOgDatoForrigeVedtakNull() {
+        VedtakDto vedtakDto = new VedtakDto();
+        vedtakDto.setErFørstegangsvedtak(true);
+        sedData.setVedtakDto(vedtakDto);
+
+
+        SED sed = sedMapper.mapTilSed(sedData);
+
+        assertThat(sed.getMedlemskap().getClass()).isEqualTo(MedlemskapA003.class);
+        MedlemskapA003 medlemskapA003 = (MedlemskapA003) sed.getMedlemskap();
+        assertThat(medlemskapA003).isNotNull();
+        assertThat(medlemskapA003.getVedtak().getEropprinneligvedtak()).isEqualTo("ja");
+        assertThat(medlemskapA003.getVedtak().getErendringsvedtak()).isNull();
+        assertThat(medlemskapA003.getVedtak().getDatoforrigevedtak()).isNull();
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A009MapperTest.java
@@ -12,7 +12,6 @@ import no.nav.melosys.eessi.models.exception.MappingException;
 import no.nav.melosys.eessi.models.sed.SED;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA009;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +57,7 @@ class A009MapperTest {
     }
 
     @Test
-    void erIkkeOpprinneligVedtak_ErOpprinneligVedtaksNeiOgDatoForrigeVedtakIkkeNull() {
+    void erIkkeOpprinneligVedtak_ErOpprinneligVedtakOgErEndringsvedtakSattKorrektOgDatoForrigeVedtakIkkeNull() {
         VedtakDto vedtakDto = new VedtakDto();
         vedtakDto.setErFørstegangsvedtak(false);
         vedtakDto.setDatoForrigeVedtak(LocalDate.now());
@@ -69,12 +68,29 @@ class A009MapperTest {
 
 
         assertThat(sed.getMedlemskap().getClass()).isEqualTo(MedlemskapA009.class);
-
         MedlemskapA009 medlemskapA009 = (MedlemskapA009) sed.getMedlemskap();
-
         assertThat(medlemskapA009).isNotNull();
-        assertThat(medlemskapA009.getVedtak().getEropprinneligvedtak()).isEqualTo("nei");
+        assertThat(medlemskapA009.getVedtak().getEropprinneligvedtak()).isNull();
+        assertThat(medlemskapA009.getVedtak().getErendringsvedtak()).isEqualTo("nei");
         assertThat(medlemskapA009.getVedtak().getDatoforrigevedtak()).isEqualTo(LocalDate.now().toString());
+    }
+
+    @Test
+    void erOpprinneligVedtak_ErOpprinneligVedtakOgErEndringsvedtakSattKorrektOgDatoForrigeVedtakNull() {
+        VedtakDto vedtakDto = new VedtakDto();
+        vedtakDto.setErFørstegangsvedtak(true);
+        sedData.setVedtakDto(vedtakDto);
+
+
+        SED sed = a009Mapper.mapTilSed(sedData);
+
+
+        assertThat(sed.getMedlemskap().getClass()).isEqualTo(MedlemskapA009.class);
+        MedlemskapA009 medlemskapA009 = (MedlemskapA009) sed.getMedlemskap();
+        assertThat(medlemskapA009).isNotNull();
+        assertThat(medlemskapA009.getVedtak().getEropprinneligvedtak()).isEqualTo("ja");
+        assertThat(medlemskapA009.getVedtak().getErendringsvedtak()).isNull();
+        assertThat(medlemskapA009.getVedtak().getDatoforrigevedtak()).isNull();
     }
 
     @Test
@@ -98,15 +114,15 @@ class A009MapperTest {
     void getMedlemskapFeilLovvalgsBestemmelse_expectMappingException() {
         sedData.getLovvalgsperioder().get(0).setBestemmelse(Bestemmelse.ART_13_4);
         assertThatExceptionOfType(MappingException.class)
-                .isThrownBy(() -> a009Mapper.mapTilSed(sedData))
-                .withMessageContaining("Lovvalgsbestemmelse er ikke av artikkel 12!");
+            .isThrownBy(() -> a009Mapper.mapTilSed(sedData))
+            .withMessageContaining("Lovvalgsbestemmelse er ikke av artikkel 12!");
     }
 
     @Test
     void ingenLovvalgsperioder_expectNullPointerException() {
         sedData.setLovvalgsperioder(null);
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> a009Mapper.mapTilSed(sedData));
+            .isThrownBy(() -> a009Mapper.mapTilSed(sedData));
     }
 
     @Test

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/mapper/til_sed/lovvalg/A010MapperTest.java
@@ -11,11 +11,10 @@ import no.nav.melosys.eessi.controller.dto.VedtakDto;
 import no.nav.melosys.eessi.models.SedType;
 import no.nav.melosys.eessi.models.exception.MappingException;
 import no.nav.melosys.eessi.models.sed.SED;
-import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA003;
 import no.nav.melosys.eessi.models.sed.medlemskap.impl.MedlemskapA010;
 import no.nav.melosys.eessi.service.sed.SedDataStub;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
@@ -71,7 +70,7 @@ class A010MapperTest {
     }
 
     @Test
-    void mapTilSed_erIkkeOpprinneligVedtak_ErOpprinneligVedtaksNeiOgDatoForrigeVedtakIkkeNull() {
+    void mapTilSed_erIkkeOpprinneligVedtak_ErOpprinneligVedtaksOgErEndringsvedtakSattKorrektOgDatoForrigeVedtakIkkeNull() {
         lovvalgsperiode.setBestemmelse(Bestemmelse.ART_11_3_a);
         lovvalgsperiode.setTilleggsBestemmelse(Bestemmelse.ART_11_3_b);
         VedtakDto vedtakDto = new VedtakDto();
@@ -84,12 +83,31 @@ class A010MapperTest {
 
 
         assertThat(sed.getMedlemskap().getClass()).isEqualTo(MedlemskapA010.class);
-
         MedlemskapA010 medlemskapA010 = (MedlemskapA010) sed.getMedlemskap();
-
         assertThat(medlemskapA010).isNotNull();
-        assertThat(medlemskapA010.getVedtak().getEropprinneligvedtak()).isEqualTo("nei");
+        assertThat(medlemskapA010.getVedtak().getEropprinneligvedtak()).isNull();
+        assertThat(medlemskapA010.getVedtak().getErendringsvedtak()).isEqualTo("nei");
         assertThat(medlemskapA010.getVedtak().getDatoforrigevedtak()).isEqualTo(LocalDate.now().toString());
+    }
+
+    @Test
+    void mapTilSed_erOpprinneligVedtak_ErOpprinneligVedtaksOgErEndringsvedtakSattKorrektOgDatoForrigeVedtakNull() {
+        lovvalgsperiode.setBestemmelse(Bestemmelse.ART_11_3_a);
+        lovvalgsperiode.setTilleggsBestemmelse(Bestemmelse.ART_11_3_b);
+        VedtakDto vedtakDto = new VedtakDto();
+        vedtakDto.setErFørstegangsvedtak(true);
+        sedData.setVedtakDto(vedtakDto);
+
+
+        SED sed = a010Mapper.mapTilSed(sedData);
+
+
+        assertThat(sed.getMedlemskap().getClass()).isEqualTo(MedlemskapA010.class);
+        MedlemskapA010 medlemskapA010 = (MedlemskapA010) sed.getMedlemskap();
+        assertThat(medlemskapA010).isNotNull();
+        assertThat(medlemskapA010.getVedtak().getEropprinneligvedtak()).isEqualTo("ja");
+        assertThat(medlemskapA010.getVedtak().getErendringsvedtak()).isNull();
+        assertThat(medlemskapA010.getVedtak().getDatoforrigevedtak()).isNull();
     }
 
     @Test
@@ -99,6 +117,6 @@ class A010MapperTest {
         lovvalgsperiode.setTilleggsBestemmelse(Bestemmelse.ART_12_1);
 
         assertThatExceptionOfType(MappingException.class).isThrownBy(() -> a010Mapper.mapTilSed(sedData))
-                .withMessageContaining("Kan ikke mappe til bestemmelse i A010 for lovvalgsperiode ");
+            .withMessageContaining("Kan ikke mappe til bestemmelse i A010 for lovvalgsperiode ");
     }
 }


### PR DESCRIPTION
Ser tilsynelatende ut som om vi alltid svarer på spørsmålet: "**Er dette et opprinnelig vedtak?**", men at man svarer på ulikt felt avhengig av om det er et opprinnelig vedtak eller ikke. 

- Er svaret **JA** (det er opprinnelig vedtak) setter man `eropprinneligvedtak` = "ja", og `erendringsvedtak` forblir default null. 
- Er svaret **NEI** (det er endringsvedtak) setter man `erendringsvedtak` = "nei", og `eropprinneligvedtak` forblir default null. 

Da gir det også meningen at `eropprinneligvedtak` kun kan være "ja" og null, mens `erendringsvedtak` kun kan være "nei" og null.  

Testet med manuell deploy til Q2 og får ønsket resultat både for endring og opprinnelig vedtak.

https://jira.adeo.no/browse/MELOSYS-6472