### PR TITLE
6363 sett limit for mottatte seder

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/SedMottattHendelseRepository.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/repository/SedMottattHendelseRepository.java
@@ -23,7 +23,7 @@ public interface SedMottattHendelseRepository extends JpaRepository<SedMottattHe
     int countAllByRinaSaksnummer(String rinaSaksnummer);
 
     @Query(
-            value = "select * from sed_mottatt_hendelse where sed_hendelse ->> 'sedId' = ?1",
+            value = "select * from sed_mottatt_hendelse where sed_hendelse ->> 'sedId' = ?1 order by mottatt_dato limit 1",
             nativeQuery = true)
     Optional<SedMottattHendelse> findBySedID(String sedID);
 


### PR DESCRIPTION
Der er en mulighet for duplikate innslag i databasen når vi mottar batch meldinger på kafka køen. Det er vanskelig å fange opp disse ved lagring. Vi har allerede en sjekk for duplikater, men det virker som att den ikke alltid fanger opp dette når vi mottar meldinger som kommer veldig raskt etter hverandre.
https://jira.adeo.no/browse/MELOSYS-6363