### PR TITLE
6601: Kartlegge sendte SED med vedlegg i feilperiode

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/SedJournalføringAdminTjeneste.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/SedJournalføringAdminTjeneste.java
@@ -8,6 +8,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+
 @Slf4j
 @Unprotected
 @RestController
@@ -26,18 +29,34 @@ public class SedJournalføringAdminTjeneste {
         this.sedJournalføringMigreringService = sedJournalføringMigreringService;
     }
 
-    @PostMapping("/sed/sed-med-vedlegg/start")
-    public ResponseEntity<String> startKartleggingAvVedleggMedSed(@RequestHeader(API_KEY_HEADER) String apiKey) {
+    @PostMapping("/sed/sed-med-vedlegg/mottatt/start")
+    public ResponseEntity<String> startKartleggingAvSedMottattMedVedlegg(@RequestHeader(API_KEY_HEADER) String apiKey) {
         validerApikey(apiKey);
         sedJournalføringMigreringService.startKartleggingAvSedMottatt();
 
-        return ResponseEntity.ok("Startet rapportering av sed med vedlegg");
+        return ResponseEntity.ok("Startet rapportering av sed mottatt med vedlegg");
     }
 
-    @PostMapping("/sed/sed-med-vedlegg/stop")
-    public ResponseEntity<String> stoppKartleggingAvVedleggMedSed(@RequestHeader(API_KEY_HEADER) String apiKey) {
+    @PostMapping("/sed/sed-med-vedlegg/sendt/start")
+    public ResponseEntity<String> startKartleggingAvSedSendtMedVedlegg(@RequestHeader(API_KEY_HEADER) String apiKey) throws IOException, URISyntaxException {
         validerApikey(apiKey);
-        sedJournalføringMigreringService.stoppKartlegging();
+        sedJournalføringMigreringService.startKartleggingAvSedSendt();
+
+        return ResponseEntity.ok("Startet rapportering av sed sendt med vedlegg");
+    }
+
+
+    @PostMapping("/sed/sed-med-vedlegg/mottatt/stop")
+    public ResponseEntity<String> stoppKartleggingAvSedMottattMedVedlegg(@RequestHeader(API_KEY_HEADER) String apiKey) {
+        validerApikey(apiKey);
+        sedJournalføringMigreringService.stoppSedMottattKartlegging();
+        return ResponseEntity.ok("Stoppet rapportering av sed med vedlegg");
+    }
+
+    @PostMapping("/sed/sed-med-vedlegg/sendt/stop")
+    public ResponseEntity<String> stoppKartleggingAvSedSendtMedVedlegg(@RequestHeader(API_KEY_HEADER) String apiKey) {
+        validerApikey(apiKey);
+        sedJournalføringMigreringService.stoppSedMendtKartlegging();
         return ResponseEntity.ok("Stoppet rapportering av sed med vedlegg");
     }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedJournalføringMigreringRapportDto.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedJournalføringMigreringRapportDto.java
@@ -9,6 +9,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class SedJournalføringMigreringRapportDto {
     private final List<SedMottattMigreringRapportDto> sedMottattMigreringRapportDtoList;
+    private final List<SedSendtMigreringRapportDto> sedSendtMigreringRapportDtoList;
     private int antallSedMottattHendelser;
     private int antallSedSjekket;
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedJournalføringMigreringService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedJournalføringMigreringService.java
@@ -1,9 +1,17 @@
 package no.nav.melosys.eessi.service.sed;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.melosys.eessi.integration.eux.rina_api.EuxConsumer;
@@ -30,20 +38,25 @@ public class SedJournalføringMigreringService {
         this.naisClusterName = System.getenv().getOrDefault("NAIS_CLUSTER_NAME", "prod-fss");
     }
 
-
     // PROD:
     LocalDateTime startTidspunktProd = LocalDateTime.of(2024, 4, 18, 13, 37);
     LocalDateTime sluttTidspunktProd = LocalDateTime.of(2024, 4, 24, 15, 37);
+    final String fileNameProd = "migrering-sed-sendt-prod.json";
 
     // DEV:
     LocalDateTime startTidspunktDev = LocalDateTime.of(2024, 4, 1, 13, 37);
     LocalDateTime sluttTidspunktDev = LocalDateTime.of(2024, 4, 25, 15, 37);
-
-    boolean erKartleggingPågående = false;
+    final String fileNameDev = "migrering-sed-sendt-dev.json";
 
     private final List<SedMottattMigreringRapportDto> sedMottattMigreringRapportDtoList = new ArrayList<>();
+    volatile boolean erKartleggingSedMottattPågående = false;
     private int antallSedMottattHendelser = 0;
-    private int antallSedSjekket = 0;
+    private int antallSedMottattSjekket = 0;
+
+    private final List<SedSendtMigreringRapportDto> sedSendtMigreringRapportDtoList = new ArrayList<>();
+    volatile boolean erKartleggingSedSendtPågående = false;
+    private int antallSedSendtHendelser = 0;
+    private int antallSedSendtSjekket = 0;
 
     @Async
     @Synchronized
@@ -52,36 +65,74 @@ public class SedJournalføringMigreringService {
         LocalDateTime sluttTidspunkt = naisClusterName.equals("prod-fss") ? sluttTidspunktProd : sluttTidspunktDev;
 
         List<SedMottattHendelse> sedMottattHendelseListe = sedMottattHendelseRepository.findAllByMottattDatoBetween(startTidspunkt, sluttTidspunkt);
-        erKartleggingPågående = true;
+        erKartleggingSedMottattPågående = true;
         antallSedMottattHendelser = sedMottattHendelseListe.size();
-        antallSedSjekket = 0;
+        antallSedMottattSjekket = 0;
 
         sedMottattMigreringRapportDtoList.clear();
 
         log.info("Starter rapportering av sed med vedlegg fra {} til {}. Antall SedMottattHendelser {}", startTidspunkt, sluttTidspunkt, antallSedMottattHendelser);
 
         for (SedMottattHendelse sedMottattHendelse : sedMottattHendelseListe) {
-            if (!erKartleggingPågående) {
+            if (!erKartleggingSedMottattPågående) {
                 break;
             }
             kartleggForSedMottattHendelse(sedMottattHendelse);
         }
-        erKartleggingPågående = false;
+        erKartleggingSedMottattPågående = false;
     }
 
-    public void stoppKartlegging() {
-        log.info("Stopp rapportering av sed med vedlegg. Sjekket {} SED. Funnet {} av {} sed med vedlegg.", antallSedSjekket, sedMottattMigreringRapportDtoList.size(), antallSedMottattHendelser);
-        erKartleggingPågående = false;
+    @Async
+    @Synchronized
+    public void startKartleggingAvSedSendt() throws IOException, URISyntaxException {
+        erKartleggingSedSendtPågående = true;
+        antallSedSendtSjekket = 0;
+        String fileName = naisClusterName.equals("prod-fss") ? fileNameProd : fileNameDev;
+
+        URI fileUri = (Objects.requireNonNull(getClass().getClassLoader().getResource(fileName))).toURI();
+        String content = new String(Files.readAllBytes(Paths.get(fileUri)));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<SedSendtJournalføringMigrering> sedSendtJournalføringListe = objectMapper.readValue(content, new TypeReference<>() {
+        });
+        antallSedSendtHendelser = sedSendtJournalføringListe.size();
+
+        log.info("Starter rapportering av sed sendt med vedlegg fra {}. Antall SedSendtJournalføring {}", fileName, antallSedSendtHendelser);
+
+        for (SedSendtJournalføringMigrering sedSendtJournalføring : sedSendtJournalføringListe) {
+            if (!erKartleggingSedSendtPågående) {
+                break;
+            }
+            String rinaSaksnummer = sedSendtJournalføring.rinaSakId();
+            String dokumentId = sedSendtJournalføring.rinaDokumentId();
+
+            SedMedVedlegg sedMedVedlegg = euxConsumer.hentSedMedVedlegg(rinaSaksnummer, dokumentId);
+            if (!sedMedVedlegg.getVedlegg().isEmpty()) {
+                log.info("Fant vedlegg for sed med rinaSaksnummer {}, dokumentId {}", rinaSaksnummer, dokumentId);
+                sedSendtMigreringRapportDtoList.add(new SedSendtMigreringRapportDto(rinaSaksnummer, dokumentId));
+            }
+            antallSedSendtSjekket++;
+        }
+    }
+
+    public void stoppSedMottattKartlegging() {
+        log.info("Stopp rapportering av sed mottatt med vedlegg. Sjekket {} SED. Funnet {} av {} sed med vedlegg.", antallSedMottattSjekket, sedMottattMigreringRapportDtoList.size(), antallSedMottattHendelser);
+        erKartleggingSedMottattPågående = false;
+    }
+
+    public void stoppSedMendtKartlegging() {
+        log.info("Stopp rapportering av sed sendt med vedlegg. Sjekket {} SED. Funnet {} av {} sed med vedlegg.", antallSedSendtSjekket, sedSendtMigreringRapportDtoList.size(), antallSedMottattHendelser);
+        erKartleggingSedSendtPågående = false;
     }
 
     public SedJournalføringMigreringRapportDto hentStatus() {
-        return new SedJournalføringMigreringRapportDto(sedMottattMigreringRapportDtoList, antallSedMottattHendelser, antallSedSjekket);
+        return new SedJournalføringMigreringRapportDto(sedMottattMigreringRapportDtoList, sedSendtMigreringRapportDtoList, antallSedMottattHendelser, antallSedMottattSjekket);
     }
 
     private void kartleggForSedMottattHendelse(SedMottattHendelse sedMottattHendelse) {
         String rinaSaksnummer = sedMottattHendelse.getSedHendelse().getRinaSakId();
         String dokumentId = sedMottattHendelse.getSedHendelse().getRinaDokumentId();
-        antallSedSjekket++;
+        antallSedMottattSjekket++;
 
         SedMedVedlegg sedMedVedlegg = euxConsumer.hentSedMedVedlegg(rinaSaksnummer, dokumentId);
         if (!sedMedVedlegg.getVedlegg().isEmpty()) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedSendtJournalføringMigrering.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedSendtJournalføringMigrering.java
@@ -1,0 +1,8 @@
+package no.nav.melosys.eessi.service.sed;
+
+public record SedSendtJournalføringMigrering(
+    String sedId,
+    String rinaSakId,
+    String rinaDokumentId
+) {
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedSendtMigreringRapportDto.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedSendtMigreringRapportDto.java
@@ -1,0 +1,11 @@
+package no.nav.melosys.eessi.service.sed;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SedSendtMigreringRapportDto {
+    private final String rinaSaksnummer;
+    private final String dokumentId;
+}

--- a/melosys-eessi-app/src/main/resources/migrering-sed-sendt-dev.json
+++ b/melosys-eessi-app/src/main/resources/migrering-sed-sendt-dev.json
@@ -1,0 +1,117 @@
+[
+    {
+        "sedId": "1448216_137c25a112954ef2a0870a15e7eb00d6_2",
+        "rinaSakId": "1448216",
+        "rinaDokumentId": "137c25a112954ef2a0870a15e7eb00d6"
+    },
+    {
+        "sedId": "1448215_288c7637f43f4bc0b8d8f1f2682bc622_2",
+        "rinaSakId": "1448215",
+        "rinaDokumentId": "288c7637f43f4bc0b8d8f1f2682bc622"
+    },
+    {
+        "sedId": "1448214_1b0cdc34404a4972bfcfd7c7f8483d7f_2",
+        "rinaSakId": "1448214",
+        "rinaDokumentId": "1b0cdc34404a4972bfcfd7c7f8483d7f"
+    },
+    {
+        "sedId": "1448210_33cd6c1b79cf470dbd44e604a7c2c23c_1",
+        "rinaSakId": "1448210",
+        "rinaDokumentId": "33cd6c1b79cf470dbd44e604a7c2c23c"
+    },
+    {
+        "sedId": "1448201_eeddeac2df8149f6831a2f3ceab2542c_1",
+        "rinaSakId": "1448201",
+        "rinaDokumentId": "eeddeac2df8149f6831a2f3ceab2542c"
+    },
+    {
+        "sedId": "1448208_d5383f19446442979aa32f148fea7e69_2",
+        "rinaSakId": "1448208",
+        "rinaDokumentId": "d5383f19446442979aa32f148fea7e69"
+    },
+    {
+        "sedId": "1448201_4f59656b4c714609aada27cd176b6ab4_1",
+        "rinaSakId": "1448201",
+        "rinaDokumentId": "4f59656b4c714609aada27cd176b6ab4"
+    },
+    {
+        "sedId": "1448195_97dac3d70ad74adbbc449edf01cd0f12_1",
+        "rinaSakId": "1448195",
+        "rinaDokumentId": "97dac3d70ad74adbbc449edf01cd0f12"
+    },
+    {
+        "sedId": "1448194_e79ead7fcf8049b6a312f7abe42aa07f_1",
+        "rinaSakId": "1448194",
+        "rinaDokumentId": "e79ead7fcf8049b6a312f7abe42aa07f"
+    },
+    {
+        "sedId": "1448187_0544a46ee4e24f9abdb0abc23e2602a3_1",
+        "rinaSakId": "1448187",
+        "rinaDokumentId": "0544a46ee4e24f9abdb0abc23e2602a3"
+    },
+    {
+        "sedId": "1448176_6d24beadefb74a2ba4e0cbbd2a6e58be_1",
+        "rinaSakId": "1448176",
+        "rinaDokumentId": "6d24beadefb74a2ba4e0cbbd2a6e58be"
+    },
+    {
+        "sedId": "1448189_62a87e8743db48f3bed14fcab79adfa4_2",
+        "rinaSakId": "1448189",
+        "rinaDokumentId": "62a87e8743db48f3bed14fcab79adfa4"
+    },
+    {
+        "sedId": "1448187_6b90592877784454ba6311e319b7b3c3_1",
+        "rinaSakId": "1448187",
+        "rinaDokumentId": "6b90592877784454ba6311e319b7b3c3"
+    },
+    {
+        "sedId": "1448179_12accdf882624655a5d2b4385bc0fece_2",
+        "rinaSakId": "1448179",
+        "rinaDokumentId": "12accdf882624655a5d2b4385bc0fece"
+    },
+    {
+        "sedId": "1448179_12accdf882624655a5d2b4385bc0fece_2",
+        "rinaSakId": "1448179",
+        "rinaDokumentId": "12accdf882624655a5d2b4385bc0fece"
+    },
+    {
+        "sedId": "1448178_f179bb3170f74ed1be2e5a18d020375d_1",
+        "rinaSakId": "1448178",
+        "rinaDokumentId": "f179bb3170f74ed1be2e5a18d020375d"
+    },
+    {
+        "sedId": "1448176_208650c1b3d04245a6cf1e9ed7d134fc_1",
+        "rinaSakId": "1448176",
+        "rinaDokumentId": "208650c1b3d04245a6cf1e9ed7d134fc"
+    },
+    {
+        "sedId": "1448169_28fcfc0152f64fe9b3e6d3ae987bdc2a_2",
+        "rinaSakId": "1448169",
+        "rinaDokumentId": "28fcfc0152f64fe9b3e6d3ae987bdc2a"
+    },
+    {
+        "sedId": "1447943_b74da592813f4db4a10cdaa8a132ff82_1",
+        "rinaSakId": "1447943",
+        "rinaDokumentId": "b74da592813f4db4a10cdaa8a132ff82"
+    },
+    {
+        "sedId": "1447928_c9d32b6b4ecb4719842cf2f3dd7750cb_1",
+        "rinaSakId": "1447928",
+        "rinaDokumentId": "c9d32b6b4ecb4719842cf2f3dd7750cb"
+    },
+    {
+        "sedId": "1447937_d92b5216fc534ab79a5dc2103bb8af35_1",
+        "rinaSakId": "1447937",
+        "rinaDokumentId": "d92b5216fc534ab79a5dc2103bb8af35"
+    },
+    {
+        "sedId": "1447936_4ce0d79731be4bbe8cbdb208f32e67da_1",
+        "rinaSakId": "1447936",
+        "rinaDokumentId": "4ce0d79731be4bbe8cbdb208f32e67da"
+    },
+    {
+        "sedId": "1447942_4b5b0879b7be4022a7dcdf33a28ed2b6_1",
+        "rinaSakId": "1447942",
+        "rinaDokumentId": "4b5b0879b7be4022a7dcdf33a28ed2b6"
+    }
+]

--- a/melosys-eessi-app/src/main/resources/migrering-sed-sendt-prod.json
+++ b/melosys-eessi-app/src/main/resources/migrering-sed-sendt-prod.json
@@ -1,0 +1,927 @@
+[
+    {
+        "sedId": "11274293_9d409a9216db4cf698242927d3da04e4_1",
+        "rinaSakId": "11274293",
+        "rinaDokumentId": "9d409a9216db4cf698242927d3da04e4"
+    },
+    {
+        "sedId": "11277035_c6231c8dcdca43c18ec10cb95f8a00db_1",
+        "rinaSakId": "11277035",
+        "rinaDokumentId": "c6231c8dcdca43c18ec10cb95f8a00db"
+    },
+    {
+        "sedId": "7910125_47defa3125274eae850ca494f9955c57_1",
+        "rinaSakId": "7910125",
+        "rinaDokumentId": "47defa3125274eae850ca494f9955c57"
+    },
+    {
+        "sedId": "7817658_bd508e2626b549c086ed34948ebe8ffe_5",
+        "rinaSakId": "7817658",
+        "rinaDokumentId": "bd508e2626b549c086ed34948ebe8ffe"
+    },
+    {
+        "sedId": "11274282_7270dc13cf3841d986dcd2c580ff7b26_3",
+        "rinaSakId": "11274282",
+        "rinaDokumentId": "7270dc13cf3841d986dcd2c580ff7b26"
+    },
+    {
+        "sedId": "7919463_f8efc0dee2f046c3a4f67bab4e61d79c_2",
+        "rinaSakId": "7919463",
+        "rinaDokumentId": "f8efc0dee2f046c3a4f67bab4e61d79c"
+    },
+    {
+        "sedId": "11232679_3f75d10f2a494671a4f83d08effefb43_2",
+        "rinaSakId": "11232679",
+        "rinaDokumentId": "3f75d10f2a494671a4f83d08effefb43"
+    },
+    {
+        "sedId": "11232679_3f75d10f2a494671a4f83d08effefb43_1",
+        "rinaSakId": "11232679",
+        "rinaDokumentId": "3f75d10f2a494671a4f83d08effefb43"
+    },
+    {
+        "sedId": "7895035_4b2cb5965964420da026d400f62d5369_3",
+        "rinaSakId": "7895035",
+        "rinaDokumentId": "4b2cb5965964420da026d400f62d5369"
+    },
+    {
+        "sedId": "11276875_a7de50ee5267413f935ed1f257112f21_1",
+        "rinaSakId": "11276875",
+        "rinaDokumentId": "a7de50ee5267413f935ed1f257112f21"
+    },
+    {
+        "sedId": "11276843_53b95688bb8741d1a3f3dc8a65e2f71d_3",
+        "rinaSakId": "11276843",
+        "rinaDokumentId": "53b95688bb8741d1a3f3dc8a65e2f71d"
+    },
+    {
+        "sedId": "7847474_417d22e1b7e84f51a2972113087d8df7_3",
+        "rinaSakId": "7847474",
+        "rinaDokumentId": "417d22e1b7e84f51a2972113087d8df7"
+    },
+    {
+        "sedId": "11276790_bde9b88853a04fe0acfb947ecbce23dc_1",
+        "rinaSakId": "11276790",
+        "rinaDokumentId": "bde9b88853a04fe0acfb947ecbce23dc"
+    },
+    {
+        "sedId": "7884431_f2dfdc8f47af496ba1106c32c9d600b8_1",
+        "rinaSakId": "7884431",
+        "rinaDokumentId": "f2dfdc8f47af496ba1106c32c9d600b8"
+    },
+    {
+        "sedId": "11276536_32c8d5b33b964afaa5e439a4c50f74e2_4",
+        "rinaSakId": "11276536",
+        "rinaDokumentId": "32c8d5b33b964afaa5e439a4c50f74e2"
+    },
+    {
+        "sedId": "11276414_0e3df1a50082441c9187b894e020fdd5_1",
+        "rinaSakId": "11276414",
+        "rinaDokumentId": "0e3df1a50082441c9187b894e020fdd5"
+    },
+    {
+        "sedId": "10800904_99656c64e049478db623f7362cb6985a_2",
+        "rinaSakId": "10800904",
+        "rinaDokumentId": "99656c64e049478db623f7362cb6985a"
+    },
+    {
+        "sedId": "10829304_930a4bbcaba3453cb18e507d4be4505f_2",
+        "rinaSakId": "10829304",
+        "rinaDokumentId": "930a4bbcaba3453cb18e507d4be4505f"
+    },
+    {
+        "sedId": "10800904_5f66a76623cf47d8b860e584f1c7089d_2",
+        "rinaSakId": "10800904",
+        "rinaDokumentId": "5f66a76623cf47d8b860e584f1c7089d"
+    },
+    {
+        "sedId": "11274927_bf713830c3e74e90bf37b952752b8362_1",
+        "rinaSakId": "11274927",
+        "rinaDokumentId": "bf713830c3e74e90bf37b952752b8362"
+    },
+    {
+        "sedId": "11190720_7b1ed45387ae46c999f2209acf2c84d6_10",
+        "rinaSakId": "11190720",
+        "rinaDokumentId": "7b1ed45387ae46c999f2209acf2c84d6"
+    },
+    {
+        "sedId": "11276302_2f9e19d125254869bcb8028a29b317c6_1",
+        "rinaSakId": "11276302",
+        "rinaDokumentId": "2f9e19d125254869bcb8028a29b317c6"
+    },
+    {
+        "sedId": "10829983_f0697887e11a4160a6748967e531f129_1",
+        "rinaSakId": "10829983",
+        "rinaDokumentId": "f0697887e11a4160a6748967e531f129"
+    },
+    {
+        "sedId": "11274900_eed81a2975a746e7a5e6e6cb4b7df36e_1",
+        "rinaSakId": "11274900",
+        "rinaDokumentId": "eed81a2975a746e7a5e6e6cb4b7df36e"
+    },
+    {
+        "sedId": "10829981_c526a564658a4f98821114b5c34a2a51_1",
+        "rinaSakId": "10829981",
+        "rinaDokumentId": "c526a564658a4f98821114b5c34a2a51"
+    },
+    {
+        "sedId": "10834280_fca97f933acf42a5bed63bf838bb13ce_1",
+        "rinaSakId": "10834280",
+        "rinaDokumentId": "fca97f933acf42a5bed63bf838bb13ce"
+    },
+    {
+        "sedId": "11275276_b988b2581e724bf19a6416755150e42f_1",
+        "rinaSakId": "11275276",
+        "rinaDokumentId": "b988b2581e724bf19a6416755150e42f"
+    },
+    {
+        "sedId": "7895908_abaae85e5f32412e9d126cceb241bda6_1",
+        "rinaSakId": "7895908",
+        "rinaDokumentId": "abaae85e5f32412e9d126cceb241bda6"
+    },
+    {
+        "sedId": "10798527_638ceea765e64487abfe2b3fc28d5a33_1",
+        "rinaSakId": "10798527",
+        "rinaDokumentId": "638ceea765e64487abfe2b3fc28d5a33"
+    },
+    {
+        "sedId": "8002456_88cb835a740d464d825f8b6eebec82d9_1",
+        "rinaSakId": "8002456",
+        "rinaDokumentId": "88cb835a740d464d825f8b6eebec82d9"
+    },
+    {
+        "sedId": "11264926_c024b0a9cb4947078c7c071da6e28547_1",
+        "rinaSakId": "11264926",
+        "rinaDokumentId": "c024b0a9cb4947078c7c071da6e28547"
+    },
+    {
+        "sedId": "11265532_67fbb30c65fe4c38b77df943dd86e25e_1",
+        "rinaSakId": "11265532",
+        "rinaDokumentId": "67fbb30c65fe4c38b77df943dd86e25e"
+    },
+    {
+        "sedId": "11275092_b4397400f20d4a3fa8fc0e700b283e07_1",
+        "rinaSakId": "11275092",
+        "rinaDokumentId": "b4397400f20d4a3fa8fc0e700b283e07"
+    },
+    {
+        "sedId": "11272883_9202b80944ba4028b7710f51a903c637_1",
+        "rinaSakId": "11272883",
+        "rinaDokumentId": "9202b80944ba4028b7710f51a903c637"
+    },
+    {
+        "sedId": "7912893_987cb16205a24a2db2ab8fc96db6b61f_1",
+        "rinaSakId": "7912893",
+        "rinaDokumentId": "987cb16205a24a2db2ab8fc96db6b61f"
+    },
+    {
+        "sedId": "11275026_b9e9254f57274657adba17f0a337cb33_5",
+        "rinaSakId": "11275026",
+        "rinaDokumentId": "b9e9254f57274657adba17f0a337cb33"
+    },
+    {
+        "sedId": "7869729_dac48f1d93de4d19be76a7142e2ede5e_2",
+        "rinaSakId": "7869729",
+        "rinaDokumentId": "dac48f1d93de4d19be76a7142e2ede5e"
+    },
+    {
+        "sedId": "11186770_0d90ea51a7f94abf842c5031bf5f7676_1",
+        "rinaSakId": "11186770",
+        "rinaDokumentId": "0d90ea51a7f94abf842c5031bf5f7676"
+    },
+    {
+        "sedId": "11274941_e3b14910f13b4f849f0646f8584c663f_4",
+        "rinaSakId": "11274941",
+        "rinaDokumentId": "e3b14910f13b4f849f0646f8584c663f"
+    },
+    {
+        "sedId": "11274896_c0ae450f3ece487086f440c0a7fddf36_1",
+        "rinaSakId": "11274896",
+        "rinaDokumentId": "c0ae450f3ece487086f440c0a7fddf36"
+    },
+    {
+        "sedId": "11274850_9eb5ba7cddcc478e930e38b7b36fe57d_4",
+        "rinaSakId": "11274850",
+        "rinaDokumentId": "9eb5ba7cddcc478e930e38b7b36fe57d"
+    },
+    {
+        "sedId": "11267352_a55561cb3c134ab180feabfa9fce4636_1",
+        "rinaSakId": "11267352",
+        "rinaDokumentId": "a55561cb3c134ab180feabfa9fce4636"
+    },
+    {
+        "sedId": "11274752_17b69c976df94e58a03235c5ad6196c0_1",
+        "rinaSakId": "11274752",
+        "rinaDokumentId": "17b69c976df94e58a03235c5ad6196c0"
+    },
+    {
+        "sedId": "11274726_0f826810721e4de1a2b7aef48fb53bef_1",
+        "rinaSakId": "11274726",
+        "rinaDokumentId": "0f826810721e4de1a2b7aef48fb53bef"
+    },
+    {
+        "sedId": "11274696_b328a4253921463a8b5425f3540e8267_4",
+        "rinaSakId": "11274696",
+        "rinaDokumentId": "b328a4253921463a8b5425f3540e8267"
+    },
+    {
+        "sedId": "11274696_b328a4253921463a8b5425f3540e8267_3",
+        "rinaSakId": "11274696",
+        "rinaDokumentId": "b328a4253921463a8b5425f3540e8267"
+    },
+    {
+        "sedId": "11274563_11007ed58e014a19843be4bfbe7adcd7_1",
+        "rinaSakId": "11274563",
+        "rinaDokumentId": "11007ed58e014a19843be4bfbe7adcd7"
+    },
+    {
+        "sedId": "11273067_99f1be1b833a470dbc04a2ba7f43667c_1",
+        "rinaSakId": "11273067",
+        "rinaDokumentId": "99f1be1b833a470dbc04a2ba7f43667c"
+    },
+    {
+        "sedId": "11274514_63fd05dba68d405eacbf9f33cbbef44c_8",
+        "rinaSakId": "11274514",
+        "rinaDokumentId": "63fd05dba68d405eacbf9f33cbbef44c"
+    },
+    {
+        "sedId": "11118630_122c5705e1804c5585f04f8858d62e25_1",
+        "rinaSakId": "11118630",
+        "rinaDokumentId": "122c5705e1804c5585f04f8858d62e25"
+    },
+    {
+        "sedId": "11274511_fcc9548d11f64e378eccd20a7e7245e8_1",
+        "rinaSakId": "11274511",
+        "rinaDokumentId": "fcc9548d11f64e378eccd20a7e7245e8"
+    },
+    {
+        "sedId": "11274442_3a8e7ef810ce41a8a7e1dd43690390a3_1",
+        "rinaSakId": "11274442",
+        "rinaDokumentId": "3a8e7ef810ce41a8a7e1dd43690390a3"
+    },
+    {
+        "sedId": "11274352_e7b4e3c6cfbb40a7b7dc55bf0750f8f8_3",
+        "rinaSakId": "11274352",
+        "rinaDokumentId": "e7b4e3c6cfbb40a7b7dc55bf0750f8f8"
+    },
+    {
+        "sedId": "11274284_3cef75ac334242a3a3ad97ed5ad3a26b_4",
+        "rinaSakId": "11274284",
+        "rinaDokumentId": "3cef75ac334242a3a3ad97ed5ad3a26b"
+    },
+    {
+        "sedId": "11274293_133ceb9ac4f145ed951d3c45091526ca_2",
+        "rinaSakId": "11274293",
+        "rinaDokumentId": "133ceb9ac4f145ed951d3c45091526ca"
+    },
+    {
+        "sedId": "11274293_133ceb9ac4f145ed951d3c45091526ca_1",
+        "rinaSakId": "11274293",
+        "rinaDokumentId": "133ceb9ac4f145ed951d3c45091526ca"
+    },
+    {
+        "sedId": "7872553_46897e483e474e53ae9792b82e4f2898_3",
+        "rinaSakId": "7872553",
+        "rinaDokumentId": "46897e483e474e53ae9792b82e4f2898"
+    },
+    {
+        "sedId": "7918630_c2e7fd881ca44461ae3db647532dcad1_1",
+        "rinaSakId": "7918630",
+        "rinaDokumentId": "c2e7fd881ca44461ae3db647532dcad1"
+    },
+    {
+        "sedId": "11274056_4fbeac6cbc3448128cdad987046b844b_1",
+        "rinaSakId": "11274056",
+        "rinaDokumentId": "4fbeac6cbc3448128cdad987046b844b"
+    },
+    {
+        "sedId": "11274056_75058ae2abbd4f838230214be5a0fa6a_2",
+        "rinaSakId": "11274056",
+        "rinaDokumentId": "75058ae2abbd4f838230214be5a0fa6a"
+    },
+    {
+        "sedId": "11272401_20415e5c5af74ea284a4813cf2c3969d_1",
+        "rinaSakId": "11272401",
+        "rinaDokumentId": "20415e5c5af74ea284a4813cf2c3969d"
+    },
+    {
+        "sedId": "11272394_575b7c37fd8e464ab981977843ca3911_1",
+        "rinaSakId": "11272394",
+        "rinaDokumentId": "575b7c37fd8e464ab981977843ca3911"
+    },
+    {
+        "sedId": "11272392_dcdb89e839dd44b58f792f6bdfde7fbd_1",
+        "rinaSakId": "11272392",
+        "rinaDokumentId": "dcdb89e839dd44b58f792f6bdfde7fbd"
+    },
+    {
+        "sedId": "11272391_5ade06b9d43d445d9c637eb04b4e8843_1",
+        "rinaSakId": "11272391",
+        "rinaDokumentId": "5ade06b9d43d445d9c637eb04b4e8843"
+    },
+    {
+        "sedId": "11272390_c0c981ad345c40d3a13da7973366f8c5_1",
+        "rinaSakId": "11272390",
+        "rinaDokumentId": "c0c981ad345c40d3a13da7973366f8c5"
+    },
+    {
+        "sedId": "7891149_03c55effb526487a986c1e67e2cef485_1",
+        "rinaSakId": "7891149",
+        "rinaDokumentId": "03c55effb526487a986c1e67e2cef485"
+    },
+    {
+        "sedId": "11272346_74aa887293b9425f9c4eeea0c9553ce3_5",
+        "rinaSakId": "11272346",
+        "rinaDokumentId": "74aa887293b9425f9c4eeea0c9553ce3"
+    },
+    {
+        "sedId": "7890662_ba5cceead19a42f79becafca3a27cb3a_2",
+        "rinaSakId": "7890662",
+        "rinaDokumentId": "ba5cceead19a42f79becafca3a27cb3a"
+    },
+    {
+        "sedId": "11272307_af43b64ed0fc48aaae6f551241bf6ffe_2",
+        "rinaSakId": "11272307",
+        "rinaDokumentId": "af43b64ed0fc48aaae6f551241bf6ffe"
+    },
+    {
+        "sedId": "11272279_6e3ee6cd7c644c0a8ebf6243ae760d11_5",
+        "rinaSakId": "11272279",
+        "rinaDokumentId": "6e3ee6cd7c644c0a8ebf6243ae760d11"
+    },
+    {
+        "sedId": "7889245_66605f2f413f4960a45d688a86181d6b_6",
+        "rinaSakId": "7889245",
+        "rinaDokumentId": "66605f2f413f4960a45d688a86181d6b"
+    },
+    {
+        "sedId": "11272296_143accfce4c74d2aa4f2340f239dcd54_1",
+        "rinaSakId": "11272296",
+        "rinaDokumentId": "143accfce4c74d2aa4f2340f239dcd54"
+    },
+    {
+        "sedId": "7890916_db67377eb016454a94a5354470d589a0_2",
+        "rinaSakId": "7890916",
+        "rinaDokumentId": "db67377eb016454a94a5354470d589a0"
+    },
+    {
+        "sedId": "11272286_ef06fd03d1e34043aaed40c4efe17e79_2",
+        "rinaSakId": "11272286",
+        "rinaDokumentId": "ef06fd03d1e34043aaed40c4efe17e79"
+    },
+    {
+        "sedId": "11272268_5f247973324c4b4b9fe545a42ae618b6_4",
+        "rinaSakId": "11272268",
+        "rinaDokumentId": "5f247973324c4b4b9fe545a42ae618b6"
+    },
+    {
+        "sedId": "11272256_c7dd0280afca4389a14dabdd7013dab1_5",
+        "rinaSakId": "11272256",
+        "rinaDokumentId": "c7dd0280afca4389a14dabdd7013dab1"
+    },
+    {
+        "sedId": "7894611_5681d6398c4a4ca6b05b176fa12b3dc6_3",
+        "rinaSakId": "7894611",
+        "rinaDokumentId": "5681d6398c4a4ca6b05b176fa12b3dc6"
+    },
+    {
+        "sedId": "11272246_40ae0340609a48118c2cfcfb1579ceab_1",
+        "rinaSakId": "11272246",
+        "rinaDokumentId": "40ae0340609a48118c2cfcfb1579ceab"
+    },
+    {
+        "sedId": "11272230_2baf92fe038c43ee857a8e382ea47447_1",
+        "rinaSakId": "11272230",
+        "rinaDokumentId": "2baf92fe038c43ee857a8e382ea47447"
+    },
+    {
+        "sedId": "11268832_a00d2f50d1234041b1269899efd35052_1",
+        "rinaSakId": "11268832",
+        "rinaDokumentId": "a00d2f50d1234041b1269899efd35052"
+    },
+    {
+        "sedId": "11272200_f372432ab3bf4817bbb8fb82eba2818b_1",
+        "rinaSakId": "11272200",
+        "rinaDokumentId": "f372432ab3bf4817bbb8fb82eba2818b"
+    },
+    {
+        "sedId": "11272179_b158d90a35914c84913c8ce0ec581750_5",
+        "rinaSakId": "11272179",
+        "rinaDokumentId": "b158d90a35914c84913c8ce0ec581750"
+    },
+    {
+        "sedId": "11272178_7bf0161e54f2458bb897eac653941c23_1",
+        "rinaSakId": "11272178",
+        "rinaDokumentId": "7bf0161e54f2458bb897eac653941c23"
+    },
+    {
+        "sedId": "11268804_f0df09cbe70b4d468a6fdeabce938883_1",
+        "rinaSakId": "11268804",
+        "rinaDokumentId": "f0df09cbe70b4d468a6fdeabce938883"
+    },
+    {
+        "sedId": "11271897_e5ad7773782b4c4fb1dd2076bd29cb90_1",
+        "rinaSakId": "11271897",
+        "rinaDokumentId": "e5ad7773782b4c4fb1dd2076bd29cb90"
+    },
+    {
+        "sedId": "11271910_3461729febdf4c2ab6366482f4f8a81a_1",
+        "rinaSakId": "11271910",
+        "rinaDokumentId": "3461729febdf4c2ab6366482f4f8a81a"
+    },
+    {
+        "sedId": "11233372_33a5157a30a14f99a232cb02484cee6c_1",
+        "rinaSakId": "11233372",
+        "rinaDokumentId": "33a5157a30a14f99a232cb02484cee6c"
+    },
+    {
+        "sedId": "11272060_18889e9495f841ceb7181d47fc6adf33_4",
+        "rinaSakId": "11272060",
+        "rinaDokumentId": "18889e9495f841ceb7181d47fc6adf33"
+    },
+    {
+        "sedId": "11272035_a3a0d6d6e02f41fd8f52612c47446cb4_2",
+        "rinaSakId": "11272035",
+        "rinaDokumentId": "a3a0d6d6e02f41fd8f52612c47446cb4"
+    },
+    {
+        "sedId": "11272037_de0fa1e569674ec58fbd0490c56cfdde_3",
+        "rinaSakId": "11272037",
+        "rinaDokumentId": "de0fa1e569674ec58fbd0490c56cfdde"
+    },
+    {
+        "sedId": "10906662_0d81dc21a79b4615ae33c3ab13214e32_4",
+        "rinaSakId": "10906662",
+        "rinaDokumentId": "0d81dc21a79b4615ae33c3ab13214e32"
+    },
+    {
+        "sedId": "11271923_a9e4b076703b416fa4becd8eea15869e_2",
+        "rinaSakId": "11271923",
+        "rinaDokumentId": "a9e4b076703b416fa4becd8eea15869e"
+    },
+    {
+        "sedId": "11271937_5ef507154bce4c7ebf76adfb75e840bb_1",
+        "rinaSakId": "11271937",
+        "rinaDokumentId": "5ef507154bce4c7ebf76adfb75e840bb"
+    },
+    {
+        "sedId": "11271929_d96e648fcfc0487cad0ca7cdaf196bf6_1",
+        "rinaSakId": "11271929",
+        "rinaDokumentId": "d96e648fcfc0487cad0ca7cdaf196bf6"
+    },
+    {
+        "sedId": "11270662_9e1cd309914c46149d088d0000b799ff_1",
+        "rinaSakId": "11270662",
+        "rinaDokumentId": "9e1cd309914c46149d088d0000b799ff"
+    },
+    {
+        "sedId": "11269404_f9d4d929e548403b8bca84eac800ad55_2",
+        "rinaSakId": "11269404",
+        "rinaDokumentId": "f9d4d929e548403b8bca84eac800ad55"
+    },
+    {
+        "sedId": "10798527_b9612f8f308443e989cbb808f50dce0d_1",
+        "rinaSakId": "10798527",
+        "rinaDokumentId": "b9612f8f308443e989cbb808f50dce0d"
+    },
+    {
+        "sedId": "10816677_86ffc811e3de48edb30bd565a46a37a7_1",
+        "rinaSakId": "10816677",
+        "rinaDokumentId": "86ffc811e3de48edb30bd565a46a37a7"
+    },
+    {
+        "sedId": "10686625_44490c48940f42cd8d1c5e3dbc61dd36_2",
+        "rinaSakId": "10686625",
+        "rinaDokumentId": "44490c48940f42cd8d1c5e3dbc61dd36"
+    },
+    {
+        "sedId": "11270755_92de03ba6f494c649ac26364acab322b_3",
+        "rinaSakId": "11270755",
+        "rinaDokumentId": "92de03ba6f494c649ac26364acab322b"
+    },
+    {
+        "sedId": "11270742_218a7314819a41b8a760fbe512eee81f_6",
+        "rinaSakId": "11270742",
+        "rinaDokumentId": "218a7314819a41b8a760fbe512eee81f"
+    },
+    {
+        "sedId": "10779775_8fb9fc0d85e1428a903c1856b6447114_1",
+        "rinaSakId": "10779775",
+        "rinaDokumentId": "8fb9fc0d85e1428a903c1856b6447114"
+    },
+    {
+        "sedId": "11270730_9162d7f57c2a40538badf0faffa3a17d_3",
+        "rinaSakId": "11270730",
+        "rinaDokumentId": "9162d7f57c2a40538badf0faffa3a17d"
+    },
+    {
+        "sedId": "11270725_d5b0c0511fe8419c8092a2982a5952c3_3",
+        "rinaSakId": "11270725",
+        "rinaDokumentId": "d5b0c0511fe8419c8092a2982a5952c3"
+    },
+    {
+        "sedId": "11270724_92957eb8714a4902b921cf05cb7a7c4e_4",
+        "rinaSakId": "11270724",
+        "rinaDokumentId": "92957eb8714a4902b921cf05cb7a7c4e"
+    },
+    {
+        "sedId": "11270696_c6a3e44e78dd4b4190568c42b84ce662_4",
+        "rinaSakId": "11270696",
+        "rinaDokumentId": "c6a3e44e78dd4b4190568c42b84ce662"
+    },
+    {
+        "sedId": "11239776_3e9de6decf3b4a3eab54f4cc3fab3401_1",
+        "rinaSakId": "11239776",
+        "rinaDokumentId": "3e9de6decf3b4a3eab54f4cc3fab3401"
+    },
+    {
+        "sedId": "10636801_9d2e543ae5cd4083adc71ddc4403ea43_2",
+        "rinaSakId": "10636801",
+        "rinaDokumentId": "9d2e543ae5cd4083adc71ddc4403ea43"
+    },
+    {
+        "sedId": "11270673_8f772fd375da43ae874e97573ebea5f3_1",
+        "rinaSakId": "11270673",
+        "rinaDokumentId": "8f772fd375da43ae874e97573ebea5f3"
+    },
+    {
+        "sedId": "10751297_0379b291fcba41eea4b0044c89d9c5f5_1",
+        "rinaSakId": "10751297",
+        "rinaDokumentId": "0379b291fcba41eea4b0044c89d9c5f5"
+    },
+    {
+        "sedId": "11270662_c7c5c00033bb40bcbb4f3fc4cc04e20a_1",
+        "rinaSakId": "11270662",
+        "rinaDokumentId": "c7c5c00033bb40bcbb4f3fc4cc04e20a"
+    },
+    {
+        "sedId": "10749450_9968d9cba48a4885afb1f68879bee410_1",
+        "rinaSakId": "10749450",
+        "rinaDokumentId": "9968d9cba48a4885afb1f68879bee410"
+    },
+    {
+        "sedId": "11270654_a7d88e58fce44d6b9afdfe9f9d82960a_3",
+        "rinaSakId": "11270654",
+        "rinaDokumentId": "a7d88e58fce44d6b9afdfe9f9d82960a"
+    },
+    {
+        "sedId": "7820324_cd2a9e61bbc94f1ba75c9bf7db7d568a_3",
+        "rinaSakId": "7820324",
+        "rinaDokumentId": "cd2a9e61bbc94f1ba75c9bf7db7d568a"
+    },
+    {
+        "sedId": "10749262_a1b90799798b477eaca7baf0a389facd_3",
+        "rinaSakId": "10749262",
+        "rinaDokumentId": "a1b90799798b477eaca7baf0a389facd"
+    },
+    {
+        "sedId": "11270635_3c8f0a36f8e546dc942fca74dc089113_10",
+        "rinaSakId": "11270635",
+        "rinaDokumentId": "3c8f0a36f8e546dc942fca74dc089113"
+    },
+    {
+        "sedId": "10749262_a1b90799798b477eaca7baf0a389facd_1",
+        "rinaSakId": "10749262",
+        "rinaDokumentId": "a1b90799798b477eaca7baf0a389facd"
+    },
+    {
+        "sedId": "10749176_6c6bb99d0f774d768936e5c5b5a86e0d_3",
+        "rinaSakId": "10749176",
+        "rinaDokumentId": "6c6bb99d0f774d768936e5c5b5a86e0d"
+    },
+    {
+        "sedId": "11270624_e6336cd055ab449b900dd73c04d57d3c_5",
+        "rinaSakId": "11270624",
+        "rinaDokumentId": "e6336cd055ab449b900dd73c04d57d3c"
+    },
+    {
+        "sedId": "11159055_722eae07e6474718a6c575b7fd9da4c4_3",
+        "rinaSakId": "11159055",
+        "rinaDokumentId": "722eae07e6474718a6c575b7fd9da4c4"
+    },
+    {
+        "sedId": "11159055_722eae07e6474718a6c575b7fd9da4c4_2",
+        "rinaSakId": "11159055",
+        "rinaDokumentId": "722eae07e6474718a6c575b7fd9da4c4"
+    },
+    {
+        "sedId": "11159055_abc67347a3114e1abd55a62129583063_2",
+        "rinaSakId": "11159055",
+        "rinaDokumentId": "abc67347a3114e1abd55a62129583063"
+    },
+    {
+        "sedId": "11270598_b66e4093146042b3bcdecbf1f6da238a_4",
+        "rinaSakId": "11270598",
+        "rinaDokumentId": "b66e4093146042b3bcdecbf1f6da238a"
+    },
+    {
+        "sedId": "11270599_1b0a082ca54a4d07a571f2d24ad575f6_4",
+        "rinaSakId": "11270599",
+        "rinaDokumentId": "1b0a082ca54a4d07a571f2d24ad575f6"
+    },
+    {
+        "sedId": "11270580_dd7f6f9cef974b59ae1d87ab194eb4c0_1",
+        "rinaSakId": "11270580",
+        "rinaDokumentId": "dd7f6f9cef974b59ae1d87ab194eb4c0"
+    },
+    {
+        "sedId": "11269798_334d1cabf3d542f7890834067db2109c_1",
+        "rinaSakId": "11269798",
+        "rinaDokumentId": "334d1cabf3d542f7890834067db2109c"
+    },
+    {
+        "sedId": "11269721_8b4033cd1ca04d3aa9ca19ddf74ecb1f_1",
+        "rinaSakId": "11269721",
+        "rinaDokumentId": "8b4033cd1ca04d3aa9ca19ddf74ecb1f"
+    },
+    {
+        "sedId": "11269669_0e31cb893d3b4693924d28df4c783de2_1",
+        "rinaSakId": "11269669",
+        "rinaDokumentId": "0e31cb893d3b4693924d28df4c783de2"
+    },
+    {
+        "sedId": "11268883_a47c8284a88b462d83bfcbca7d79104f_1",
+        "rinaSakId": "11268883",
+        "rinaDokumentId": "a47c8284a88b462d83bfcbca7d79104f"
+    },
+    {
+        "sedId": "11268744_bab62d08a93f4188b8cae8809f00ce6e_1",
+        "rinaSakId": "11268744",
+        "rinaDokumentId": "bab62d08a93f4188b8cae8809f00ce6e"
+    },
+    {
+        "sedId": "11267198_ca19af5c30b5487da8cc9db619d4c95e_2",
+        "rinaSakId": "11267198",
+        "rinaDokumentId": "ca19af5c30b5487da8cc9db619d4c95e"
+    },
+    {
+        "sedId": "11269465_41aae0b796dc4945b7eb0296c6204c4b_1",
+        "rinaSakId": "11269465",
+        "rinaDokumentId": "41aae0b796dc4945b7eb0296c6204c4b"
+    },
+    {
+        "sedId": "11190779_a551412ef5e94ea0a58b0c81212d4333_2",
+        "rinaSakId": "11190779",
+        "rinaDokumentId": "a551412ef5e94ea0a58b0c81212d4333"
+    },
+    {
+        "sedId": "10951633_1484bfe3e9d34bae9bb3e1e4636b952a_5",
+        "rinaSakId": "10951633",
+        "rinaDokumentId": "1484bfe3e9d34bae9bb3e1e4636b952a"
+    },
+    {
+        "sedId": "11269526_bbe092c2d594424db69e02b656554e46_1",
+        "rinaSakId": "11269526",
+        "rinaDokumentId": "bbe092c2d594424db69e02b656554e46"
+    },
+    {
+        "sedId": "11269502_6697f682b48e49198101230a37282641_1",
+        "rinaSakId": "11269502",
+        "rinaDokumentId": "6697f682b48e49198101230a37282641"
+    },
+    {
+        "sedId": "11269485_c4a15cff33d44de1ba05cdbc501338d0_1",
+        "rinaSakId": "11269485",
+        "rinaDokumentId": "c4a15cff33d44de1ba05cdbc501338d0"
+    },
+    {
+        "sedId": "11269471_4bf15d99d5e245739f788d29440a789b_3",
+        "rinaSakId": "11269471",
+        "rinaDokumentId": "4bf15d99d5e245739f788d29440a789b"
+    },
+    {
+        "sedId": "11269449_e5fad5373c114afb808d460b11e6efe5_1",
+        "rinaSakId": "11269449",
+        "rinaDokumentId": "e5fad5373c114afb808d460b11e6efe5"
+    },
+    {
+        "sedId": "11269431_23ae426bc4324d0c870191b7d8ed4e9d_1",
+        "rinaSakId": "11269431",
+        "rinaDokumentId": "23ae426bc4324d0c870191b7d8ed4e9d"
+    },
+    {
+        "sedId": "11269414_3e0ac9f591cb4c3c99c301627524a7dc_1",
+        "rinaSakId": "11269414",
+        "rinaDokumentId": "3e0ac9f591cb4c3c99c301627524a7dc"
+    },
+    {
+        "sedId": "7891667_37d0fdb6433d4a55abf748a84fb52d63_1",
+        "rinaSakId": "7891667",
+        "rinaDokumentId": "37d0fdb6433d4a55abf748a84fb52d63"
+    },
+    {
+        "sedId": "11269360_777671589ce34554940d306e83f99c54_1",
+        "rinaSakId": "11269360",
+        "rinaDokumentId": "777671589ce34554940d306e83f99c54"
+    },
+    {
+        "sedId": "11267368_5de03d956b4c41f4b081cd9b2bd4b13c_2",
+        "rinaSakId": "11267368",
+        "rinaDokumentId": "5de03d956b4c41f4b081cd9b2bd4b13c"
+    },
+    {
+        "sedId": "11233934_dc4629707c92463291342f812d525fd8_1",
+        "rinaSakId": "11233934",
+        "rinaDokumentId": "dc4629707c92463291342f812d525fd8"
+    },
+    {
+        "sedId": "11260568_479ca65c2c09403e800c5f0a333b3f80_1",
+        "rinaSakId": "11260568",
+        "rinaDokumentId": "479ca65c2c09403e800c5f0a333b3f80"
+    },
+    {
+        "sedId": "11269132_2f99ea53adec4f6a9006ecaf04be2f12_3",
+        "rinaSakId": "11269132",
+        "rinaDokumentId": "2f99ea53adec4f6a9006ecaf04be2f12"
+    },
+    {
+        "sedId": "11269057_cbaa4853cb1a48a395838c3db480547f_3",
+        "rinaSakId": "11269057",
+        "rinaDokumentId": "cbaa4853cb1a48a395838c3db480547f"
+    },
+    {
+        "sedId": "11269057_cbaa4853cb1a48a395838c3db480547f_2",
+        "rinaSakId": "11269057",
+        "rinaDokumentId": "cbaa4853cb1a48a395838c3db480547f"
+    },
+    {
+        "sedId": "11269034_0bea598cd8a74cdc8d4b8b5a34391d15_1",
+        "rinaSakId": "11269034",
+        "rinaDokumentId": "0bea598cd8a74cdc8d4b8b5a34391d15"
+    },
+    {
+        "sedId": "10457993_21511dcd0cee447bbbd476863c78aafa_2",
+        "rinaSakId": "10457993",
+        "rinaDokumentId": "21511dcd0cee447bbbd476863c78aafa"
+    },
+    {
+        "sedId": "11268990_15cfe8ddaf234876b8e1585d7827f556_1",
+        "rinaSakId": "11268990",
+        "rinaDokumentId": "15cfe8ddaf234876b8e1585d7827f556"
+    },
+    {
+        "sedId": "11268986_0e9678adbc9940a197053fe2313b511c_1",
+        "rinaSakId": "11268986",
+        "rinaDokumentId": "0e9678adbc9940a197053fe2313b511c"
+    },
+    {
+        "sedId": "7892579_36f1c07254a343c8a9813921625dfa44_1",
+        "rinaSakId": "7892579",
+        "rinaDokumentId": "36f1c07254a343c8a9813921625dfa44"
+    },
+    {
+        "sedId": "11218610_0b04e99d12964a7f94ffb647345c5204_1",
+        "rinaSakId": "11218610",
+        "rinaDokumentId": "0b04e99d12964a7f94ffb647345c5204"
+    },
+    {
+        "sedId": "11268815_00dd135304a5414983bfbbbbbd5b6953_1",
+        "rinaSakId": "11268815",
+        "rinaDokumentId": "00dd135304a5414983bfbbbbbd5b6953"
+    },
+    {
+        "sedId": "11268762_7e61509765fe45f2ac08d7db4ee7d701_5",
+        "rinaSakId": "11268762",
+        "rinaDokumentId": "7e61509765fe45f2ac08d7db4ee7d701"
+    },
+    {
+        "sedId": "11268729_bb230a651bef450aaea66cfc1871ad3f_1",
+        "rinaSakId": "11268729",
+        "rinaDokumentId": "bb230a651bef450aaea66cfc1871ad3f"
+    },
+    {
+        "sedId": "7976696_7fa418cdfccf4ea4a5b31ca5cb37fa4b_4",
+        "rinaSakId": "7976696",
+        "rinaDokumentId": "7fa418cdfccf4ea4a5b31ca5cb37fa4b"
+    },
+    {
+        "sedId": "11267696_9ad0920c60c64a4da37043608fa138b9_1",
+        "rinaSakId": "11267696",
+        "rinaDokumentId": "9ad0920c60c64a4da37043608fa138b9"
+    },
+    {
+        "sedId": "11250939_1e740abee3eb48fbb47f5b945602a7e6_2",
+        "rinaSakId": "11250939",
+        "rinaDokumentId": "1e740abee3eb48fbb47f5b945602a7e6"
+    },
+    {
+        "sedId": "11265248_cb78078a2f7345eebf91f93714d84535_1",
+        "rinaSakId": "11265248",
+        "rinaDokumentId": "cb78078a2f7345eebf91f93714d84535"
+    },
+    {
+        "sedId": "11265405_3c68c59d8b9849938628aa0fbc1a9588_1",
+        "rinaSakId": "11265405",
+        "rinaDokumentId": "3c68c59d8b9849938628aa0fbc1a9588"
+    },
+    {
+        "sedId": "11267642_0e4e90a79e374ac483483ce672a2d135_1",
+        "rinaSakId": "11267642",
+        "rinaDokumentId": "0e4e90a79e374ac483483ce672a2d135"
+    },
+    {
+        "sedId": "11267627_6ab1c3331d4b4ccc92af68eb7ae506be_4",
+        "rinaSakId": "11267627",
+        "rinaDokumentId": "6ab1c3331d4b4ccc92af68eb7ae506be"
+    },
+    {
+        "sedId": "11267613_31535dc68a1a44b6938956354c0253f0_1",
+        "rinaSakId": "11267613",
+        "rinaDokumentId": "31535dc68a1a44b6938956354c0253f0"
+    },
+    {
+        "sedId": "11267250_52947f3e957b4b11a77f0ee203143185_1",
+        "rinaSakId": "11267250",
+        "rinaDokumentId": "52947f3e957b4b11a77f0ee203143185"
+    },
+    {
+        "sedId": "11267609_dfbd614531f44fb6a03f5bc04c45eada_1",
+        "rinaSakId": "11267609",
+        "rinaDokumentId": "dfbd614531f44fb6a03f5bc04c45eada"
+    },
+    {
+        "sedId": "7919057_2b65a84c798d4468bd0ef9ea9fe3cef4_1",
+        "rinaSakId": "7919057",
+        "rinaDokumentId": "2b65a84c798d4468bd0ef9ea9fe3cef4"
+    },
+    {
+        "sedId": "11148215_0be61fb0d37f4e2aa8d600268557b68e_1",
+        "rinaSakId": "11148215",
+        "rinaDokumentId": "0be61fb0d37f4e2aa8d600268557b68e"
+    },
+    {
+        "sedId": "11267583_ab4fd8558c2c495c873cb951200439ff_1",
+        "rinaSakId": "11267583",
+        "rinaDokumentId": "ab4fd8558c2c495c873cb951200439ff"
+    },
+    {
+        "sedId": "11048872_12c6871bb02c464f972cfcd52ab84690_1",
+        "rinaSakId": "11048872",
+        "rinaDokumentId": "12c6871bb02c464f972cfcd52ab84690"
+    },
+    {
+        "sedId": "11267552_dde47323145a4c33adfc3db7ef0ee2f2_4",
+        "rinaSakId": "11267552",
+        "rinaDokumentId": "dde47323145a4c33adfc3db7ef0ee2f2"
+    },
+    {
+        "sedId": "11267556_0e60b1e8080c44bfbe498b623731fa31_1",
+        "rinaSakId": "11267556",
+        "rinaDokumentId": "0e60b1e8080c44bfbe498b623731fa31"
+    },
+    {
+        "sedId": "11267555_9e5eab7e30dd4c94807723abf2e797ac_1",
+        "rinaSakId": "11267555",
+        "rinaDokumentId": "9e5eab7e30dd4c94807723abf2e797ac"
+    },
+    {
+        "sedId": "11267545_a033ed9528844468b007be6f97fe0e02_2",
+        "rinaSakId": "11267545",
+        "rinaDokumentId": "a033ed9528844468b007be6f97fe0e02"
+    },
+    {
+        "sedId": "11216380_c2c7634be0d849bc91fa35cfb271aa1e_4",
+        "rinaSakId": "11216380",
+        "rinaDokumentId": "c2c7634be0d849bc91fa35cfb271aa1e"
+    },
+    {
+        "sedId": "11267528_d3434be25e8148a6b8ed293bd150cd41_1",
+        "rinaSakId": "11267528",
+        "rinaDokumentId": "d3434be25e8148a6b8ed293bd150cd41"
+    },
+    {
+        "sedId": "11262511_3b50e69bb5914f3197b4e96d25f2c361_1",
+        "rinaSakId": "11262511",
+        "rinaDokumentId": "3b50e69bb5914f3197b4e96d25f2c361"
+    },
+    {
+        "sedId": "11267491_09aeaa57cbcc4ff480528a82d70be065_1",
+        "rinaSakId": "11267491",
+        "rinaDokumentId": "09aeaa57cbcc4ff480528a82d70be065"
+    },
+    {
+        "sedId": "10742738_7057e313d39a424f89c09d42a72c6b50_1",
+        "rinaSakId": "10742738",
+        "rinaDokumentId": "7057e313d39a424f89c09d42a72c6b50"
+    },
+    {
+        "sedId": "11159055_abc67347a3114e1abd55a62129583063_1",
+        "rinaSakId": "11159055",
+        "rinaDokumentId": "abc67347a3114e1abd55a62129583063"
+    },
+    {
+        "sedId": "11267423_c7edc337520940fe89729ae7e905a877_2",
+        "rinaSakId": "11267423",
+        "rinaDokumentId": "c7edc337520940fe89729ae7e905a877"
+    },
+    {
+        "sedId": "11267387_df15b7d87e564d3d94385c09b4b08e64_1",
+        "rinaSakId": "11267387",
+        "rinaDokumentId": "df15b7d87e564d3d94385c09b4b08e64"
+    },
+    {
+        "sedId": "11267368_5de03d956b4c41f4b081cd9b2bd4b13c_1",
+        "rinaSakId": "11267368",
+        "rinaDokumentId": "5de03d956b4c41f4b081cd9b2bd4b13c"
+    }
+]


### PR DESCRIPTION
Lastet opp fil for q2 og prod som viser oversikt over alle sendte SED. Disse vil loopes gjennom og sjekket i de miljøene.