### PR TITLE
6604 Fjerner H buc fra filter da det er for grovt

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/KafkaAivenConfig.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/config/KafkaAivenConfig.java
@@ -193,7 +193,7 @@ public class KafkaAivenConfig {
 
     private RecordFilterStrategy<String, SedHendelse> recordFilterStrategySedListener() {
         // Return false to be dismissed
-        return consumerRecord -> !(LEGISLATION_APPLICABLE_CODE_LA.equalsIgnoreCase(consumerRecord.value().getSektorKode()) || LEGISLATION_APPLICABLE_CODE_H.equalsIgnoreCase(consumerRecord.value().getSektorKode()));
+        return consumerRecord -> !(LEGISLATION_APPLICABLE_CODE_LA.equalsIgnoreCase(consumerRecord.value().getSektorKode()));
     }
 
     private RecordFilterStrategy<String, OppgaveKafkaAivenRecord> recordFilterStrategyOppgaveHendelserListener() {


### PR DESCRIPTION
H bucer leses inn for sed mottatt og sendt nå, det betyr at vi får altfor mange seder som vi ikke skulle hatt og journalfører de. Reverter akkurat denne delen av endringen så vi ikke plutselig får det i prod

Må lage en skikkelig løsning etterpå - dette er rask fiks for å unngå problemer