### PR TITLE
VAKT eux-rina-api gir oss vedlegg med null som tittel 2

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/vedlegg/SedMedVedlegg.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/vedlegg/SedMedVedlegg.kt
@@ -9,7 +9,7 @@ data class SedMedVedlegg(
 ) {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     data class BinaerFil(
-        val filnavn: String = "Vedlegg",
+        val filnavn: String? = "Vedlegg",
         val mimeType: String?,
         val innhold: ByteArray
     ) {


### PR DESCRIPTION
Filnavn må da være nullable ifm. deserialisering for å kunne kjøre videre med "Vedlegg" som default
