### PR TITLE
6909 Legg jackson-module-kotlin til i pom

### DIFF
--- a/melosys-eessi-app/pom.xml
+++ b/melosys-eessi-app/pom.xml
@@ -192,6 +192,10 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.github.microutils</groupId>
             <artifactId>kotlin-logging-jvm</artifactId>
             <version>${kotlin-logging.version}</version>


### PR DESCRIPTION
Dette fikser kotlin json serialisering hvor vi har default verdier når det kommer null fra json.

Testet at dette funker lokalt, og er greit å få dette ut i prod asap. Var litt jobb å få laget en ordentlig test på dette, så det kommer senere.  