### PR TITLE
VAKT Ikke journalfør tomt vedlegg

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/journalpostapi/OpprettJournalpostRequestMapper.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/journalpostapi/OpprettJournalpostRequestMapper.java
@@ -76,6 +76,10 @@ public final class OpprettJournalpostRequestMapper {
     private static List<Dokument> vedlegg(final SedHendelse sedHendelse, final List<SedMedVedlegg.BinaerFil> vedleggListe, SedMetrikker sedMetrikker) {
         List<Dokument> vedlegg = new ArrayList<>();
         for (SedMedVedlegg.BinaerFil binaerFil : vedleggListe) {
+            if (binaerFil.getInnhold() == null || binaerFil.getInnhold().length == 0) {
+                log.warn("Vedlegg %s har ingen innhold og blir ikke journalført for RINA saksnummer %s".formatted(binaerFil.getFilnavn(), sedHendelse.getRinaSakId()));
+                continue;
+            }
             try {
                 JournalpostFiltype opprinneligFiltype = JournalpostFiltype.fraMimeOgFilnavn(binaerFil.getMimeType(), binaerFil.getFilnavn()).orElseThrow(MappingException::new);
                 vedlegg.add(dokument(sedHendelse.getSedType(), isEmpty(binaerFil.getFilnavn()) ? "Vedlegg" : binaerFil.getFilnavn(), PDF, getPdfByteArray(binaerFil, opprinneligFiltype)));

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/journalpostapi/OpprettJournalpostRequestMapperTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/journalpostapi/OpprettJournalpostRequestMapperTest.java
@@ -17,9 +17,32 @@ class OpprettJournalpostRequestMapperTest {
     private final String ident = "123123123123";
 
     @Test
-    void opprettInngaaendeJournalpost_medPdfVedlegg_validerFelterSatt() {
-        final var vedlegg = new SedMedVedlegg.BinaerFil("vedlegg123.pdf", null, new byte[0]);
+    void opprettInngaaendeJournalpost_medTomtVedlegg_vedleggIkkeJournalfoert() {
+        final var tomtVedlegg = new SedMedVedlegg.BinaerFil("tomtVedlegg.pdf", "application/pdf", new byte[0]);
         final var sedHendelse = sedHendelse();
+
+
+        OpprettJournalpostRequest request = OpprettJournalpostRequestMapper.opprettInngaaendeJournalpost(
+            sedHendelse,
+            sedMedVedlegg(List.of(tomtVedlegg)),
+            null,
+            "dokumenttittel",
+            "behandlingstema",
+            ident,
+            sedMetrikker
+        );
+
+
+        assertThat(request.getDokumenter()).hasSize(1)
+            .flatExtracting(OpprettJournalpostRequest.Dokument::getTittel)
+            .containsExactly("dokumenttittel");
+    }
+
+    @Test
+    void opprettInngaaendeJournalpost_medPdfVedlegg_validerFelterSatt() {
+        final var vedlegg = new SedMedVedlegg.BinaerFil("vedlegg123.pdf", null, new byte[1]);
+        final var sedHendelse = sedHendelse();
+
 
         OpprettJournalpostRequest request = OpprettJournalpostRequestMapper.opprettInngaaendeJournalpost(
             sedHendelse,
@@ -30,6 +53,7 @@ class OpprettJournalpostRequestMapperTest {
             ident,
             sedMetrikker
         );
+
 
         assertThat(request.getDokumenter()).hasSize(2)
             .flatExtracting(OpprettJournalpostRequest.Dokument::getTittel)


### PR DESCRIPTION
Vi har mottatt en SED med tomt vedlegg.

#team_dokumentløsninger har en validering som forhindrer journalføring av tomt vedlegg