### PR TITLE
G4P NOJIRA: Oppgrader SpringBoot 3.3.5 -> 3.3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>3.3.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>no.nav</groupId>


### PR DESCRIPTION
Oppgraderer SpringBoot for å luke bort en del sikkerhetsissues.

Blant de er én kritisk:
https://github.com/advisories/GHSA-83qj-6fr2-vhqg - Apache Tomcat: Potential RCE and/or information disclosure and/or information corruption with partial PUT
