### PR TITLE
7268 Søking av PDL fødselsdato på personer

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLSokCriterion.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/pdl/dto/PDLSokCriterion.java
@@ -17,7 +17,7 @@ public final class PDLSokCriterion {
     }
 
     public static Builder fødselsdato() {
-        return new Builder("person.foedsel.foedselsdato");
+        return new Builder("person.foedselsdato.foedselsdato");
     }
 
     public static Builder statsborgerskap() {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/PDLServiceTest.java
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/integration/pdl/PDLServiceTest.java
@@ -188,7 +188,7 @@ class PDLServiceTest {
             .containsExactlyInAnyOrder(
                 "person.navn.fornavn",
                 "person.navn.etternavn",
-                "person.foedsel.foedselsdato"
+                "person.foedselsdato.foedselsdato"
             );
     }
 


### PR DESCRIPTION
https://jira.adeo.no/browse/MELOSYS-7268?page=com.docminer.jira.issue-links%3Acom.kintosoft.jira.links.tab-panel

Person søk søker fortsatt via de gamle feltene til PDL hvor vi søker med stien "person.foedsel.foedselsdato".
Endret stien til å samsvare med nye strukturen til PDL så den blir da "person.foedselsdato.foedselsdato"