### PR TITLE
7389: Ikke bruk OBO-tokens under admin requests

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KafkaDLQAdminTjeneste.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KafkaDLQAdminTjeneste.kt
@@ -6,6 +6,7 @@ import no.nav.melosys.eessi.integration.eux.rina_api.dto.v3.RinaSakOversiktV3
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.v3.SedAnalyseResult
 import no.nav.melosys.eessi.models.kafkadlq.KafkaDLQ
 import no.nav.melosys.eessi.models.kafkadlq.SedMottattHendelseKafkaDLQ
+import no.nav.melosys.eessi.security.ThreadLocalAccessInfo
 import no.nav.melosys.eessi.service.buc.BucAdminService
 import no.nav.melosys.eessi.service.kafkadlq.KafkaDLQService
 import no.nav.security.token.support.core.api.Protected
@@ -30,68 +31,80 @@ class KafkaDLQAdminTjeneste(
     @GetMapping
     fun hentFeiledeMeldinger(@RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<List<KafkaDLQDto>> {
         validerApikey(apiKey)
-        return ResponseEntity.ok(kafkaDLQService.hentFeiledeKafkaMeldinger().map(::mapEntitetTilDto))
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            ResponseEntity.ok(kafkaDLQService.hentFeiledeKafkaMeldinger().map(::mapEntitetTilDto))
+        }
     }
 
     @PostMapping("/{uuid}/restart")
     fun rekjørKafkaMelding(@PathVariable uuid: String, @RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<Void> {
         validerApikey(apiKey)
-        kafkaDLQService.rekjørKafkaMelding(UUID.fromString(uuid))
-        return ResponseEntity.ok().build()
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            kafkaDLQService.rekjørKafkaMelding(UUID.fromString(uuid))
+            ResponseEntity.ok().build()
+        }
     }
 
     @PostMapping("/restart/alle")
     fun rekjørAlleKafkaMeldinger(@RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<Map<String, Any>> {
         validerApikey(apiKey)
 
-        val vellykket = mutableListOf<UUID>()
-        val feilet = mutableListOf<String>()
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            val vellykket = mutableListOf<UUID>()
+            val feilet = mutableListOf<String>()
 
-        kafkaDLQService.hentFeiledeKafkaMeldinger().forEach { kafkaDLQ ->
-            kafkaDLQ.id?.let { id ->
-                try {
-                    kafkaDLQService.rekjørKafkaMelding(id)
-                    vellykket.add(id)
-                } catch (e: Exception) {
-                    feilet.add("$id: ${e.message}")
-                    log.error("Feil ved rekjøring av melding med ID {}: {}", id, e.message, e)
+            kafkaDLQService.hentFeiledeKafkaMeldinger().forEach { kafkaDLQ ->
+                kafkaDLQ.id?.let { id ->
+                    try {
+                        kafkaDLQService.rekjørKafkaMelding(id)
+                        vellykket.add(id)
+                    } catch (e: Exception) {
+                        feilet.add("$id: ${e.message}")
+                        log.error("Feil ved rekjøring av melding med ID {}: {}", id, e.message, e)
+                    }
+                } ?: run {
+                    feilet.add("Melding uten ID")
+                    log.error("Fant melding uten ID")
                 }
-            } ?: run {
-                feilet.add("Melding uten ID")
-                log.error("Fant melding uten ID")
             }
+
+            val resultat = mapOf(
+                "antallVellykket" to vellykket.size,
+                "antallFeilet" to feilet.size,
+                "vellykkedeMeldinger" to vellykket,
+                "feiledeMeldinger" to feilet
+            )
+
+            ResponseEntity.ok(resultat)
         }
-
-        val resultat = mapOf(
-            "antallVellykket" to vellykket.size,
-            "antallFeilet" to feilet.size,
-            "vellykkedeMeldinger" to vellykket,
-            "feiledeMeldinger" to feilet
-        )
-
-        return ResponseEntity.ok(resultat)
     }
 
     @GetMapping("/buc/analyse/{rinaSaksnummer}")
     fun analyserSeder(@PathVariable rinaSaksnummer: String, @RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<SedAnalyseResult> {
         validerApikey(apiKey)
         log.info { "Analyserer SEDer for sak $rinaSaksnummer" }
-        return ResponseEntity.ok(bucAdminService.analyserManglendeSeder(rinaSaksnummer))
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            ResponseEntity.ok(bucAdminService.analyserManglendeSeder(rinaSaksnummer))
+        }
     }
 
     @GetMapping("/buc/oversikt/{rinaSaksnummer}")
     fun hentRinaOversikt(@PathVariable rinaSaksnummer: String, @RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<RinaSakOversiktV3> {
         validerApikey(apiKey)
         log.info { "Henter RINA oversikt for sak $rinaSaksnummer" }
-        return ResponseEntity.ok(bucAdminService.hentRinaOversikt(rinaSaksnummer))
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            ResponseEntity.ok(bucAdminService.hentRinaOversikt(rinaSaksnummer))
+        }
     }
 
     @PostMapping("/buc/resend/{rinaSaksnummer}/{dokumentId}")
     fun resendSed(@PathVariable rinaSaksnummer: String, @PathVariable dokumentId: String, @RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<Void> {
         validerApikey(apiKey)
         log.info { "Sender SED $dokumentId på nytt for sak $rinaSaksnummer" }
-        bucAdminService.resendSed(rinaSaksnummer, dokumentId)
-        return ResponseEntity.ok().build()
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            bucAdminService.resendSed(rinaSaksnummer, dokumentId)
+            ResponseEntity.ok().build()
+        }
     }
 
     @GetMapping("/buc/analyse/alle")
@@ -99,29 +112,31 @@ class KafkaDLQAdminTjeneste(
         validerApikey(apiKey)
         log.info { "Starter analyse av alle saker med feilede meldinger i DLQ" }
 
-        val rinaSaksnumre = mutableSetOf<String>()
-        val feiledeMeldinger: List<KafkaDLQ> = kafkaDLQService.hentFeiledeKafkaMeldinger()
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            val rinaSaksnumre = mutableSetOf<String>()
+            val feiledeMeldinger: List<KafkaDLQ> = kafkaDLQService.hentFeiledeKafkaMeldinger()
 
-        for (melding: KafkaDLQ in feiledeMeldinger) {
-            if (melding is SedMottattHendelseKafkaDLQ) {
-                val sedHendelse: no.nav.melosys.eessi.kafka.consumers.SedHendelse? = melding.sedMottattHendelse
-                sedHendelse?.rinaSakId?.let { rinaSaksnumre.add(it) }
+            for (melding: KafkaDLQ in feiledeMeldinger) {
+                if (melding is SedMottattHendelseKafkaDLQ) {
+                    val sedHendelse: no.nav.melosys.eessi.kafka.consumers.SedHendelse? = melding.sedMottattHendelse
+                    sedHendelse?.rinaSakId?.let { rinaSaksnumre.add(it) }
+                }
             }
-        }
 
-        log.info { "Fant ${rinaSaksnumre.size} unike rina-saksnumre å analysere" }
+            log.info { "Fant ${rinaSaksnumre.size} unike rina-saksnumre å analysere" }
 
-        val analyseResultater = mutableListOf<SedAnalyseResult>()
-        for (rinaSaksnummer in rinaSaksnumre) {
-            try {
-                val analyse: SedAnalyseResult = bucAdminService.analyserManglendeSeder(rinaSaksnummer)
-                analyseResultater.add(analyse)
-            } catch (e: Exception) {
-                log.error(e) { "Feil ved analyse av rina-sak $rinaSaksnummer" }
+            val analyseResultater = mutableListOf<SedAnalyseResult>()
+            for (rinaSaksnummer in rinaSaksnumre) {
+                try {
+                    val analyse: SedAnalyseResult = bucAdminService.analyserManglendeSeder(rinaSaksnummer)
+                    analyseResultater.add(analyse)
+                } catch (e: Exception) {
+                    log.error(e) { "Feil ved analyse av rina-sak $rinaSaksnummer" }
+                }
             }
-        }
 
-        return ResponseEntity.ok(analyseResultater)
+            ResponseEntity.ok(analyseResultater)
+        }
     }
 
     private fun mapEntitetTilDto(entitet: KafkaDLQ): KafkaDLQDto =
@@ -141,6 +156,8 @@ class KafkaDLQAdminTjeneste(
             throw SecurityException("Ugyldig API-nøkkel")
         }
     }
+
+
 
     companion object {
         private const val API_KEY_HEADER = "X-MELOSYS-ADMIN-APIKEY"

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/ContextHolder.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/ContextHolder.java
@@ -33,7 +33,12 @@ final class ContextHolder {
         return instans;
     }
 
-    boolean canExchangeOBOToken() {
+        boolean canExchangeOBOToken() {
+        // Sjekk om vi skal bruke systemtoken basert på thread-local kontekst
+        if (ThreadLocalAccessInfo.Companion.skalBrukeSystemToken()) {
+            return false;
+        }
+        
         TokenValidationContext tokenValidationContext = getTokenContext();
         if (tokenValidationContext != null) {
             JwtToken jwtToken = tokenValidationContext.getJwtToken(AAD);

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfo.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfo.kt
@@ -1,0 +1,58 @@
+package no.nav.melosys.eessi.security
+
+import mu.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Thread-local kontekst for å håndtere tilgangsinformasjon og bestemme tokentype
+ * basert på type forespørsel (web, admin, prosess).
+ */
+class ThreadLocalAccessInfo {
+    private var erAdminForespørsel: Boolean = false
+    private var brukerId: String? = null
+
+    private fun erFraAdminForespørsel(): Boolean = erAdminForespørsel
+    private fun hentBrukerId(): String? = brukerId
+
+    companion object {
+        private val threadLocalLagring = ThreadLocal.withInitial { ThreadLocalAccessInfo() }
+
+        fun hentBrukerId(): String? {
+            val info = threadLocalLagring.get()
+            return info.hentBrukerId()
+        }
+
+        fun skalBrukeSystemToken(): Boolean {
+            val info = threadLocalLagring.get()
+            return info.erFraAdminForespørsel()
+        }
+
+        fun <T> utførSomAdminForespørsel(handling: () -> T): T {
+            val info = threadLocalLagring.get()
+            val tidligereErAdminForespørselVerdi = info.erAdminForespørsel
+
+            info.erAdminForespørsel = true
+            log.info("Utfører handling som admin forespørsel, tidligere tidligereErAdminForespørselVerdi=$tidligereErAdminForespørselVerdi")
+            return try {
+                handling()
+            } finally {
+                info.erAdminForespørsel = tidligereErAdminForespørselVerdi
+                if (!tidligereErAdminForespørselVerdi) {
+                    threadLocalLagring.remove()
+                }
+            }
+        }
+
+        fun hentInfo(): String {
+            return threadLocalLagring.get().toString()
+        }
+    }
+
+    override fun toString(): String {
+        return "ThreadLocalAccessInfo(" +
+                "erAdminForespørsel=$erAdminForespørsel, " +
+                "brukerId='$brukerId'" +
+                ")"
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfo.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfo.kt
@@ -44,9 +44,7 @@ class ThreadLocalAccessInfo {
             }
         }
 
-        fun hentInfo(): String {
-            return threadLocalLagring.get().toString()
-        }
+        fun hentInfo(): String = threadLocalLagring.get().toString()
     }
 
     override fun toString(): String {

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ContextHolderIntegrationTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ContextHolderIntegrationTest.kt
@@ -1,6 +1,6 @@
 package no.nav.melosys.eessi.security
 
-import org.assertj.core.api.Assertions.assertThat
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 class ContextHolderIntegrationTest {
@@ -8,40 +8,40 @@ class ContextHolderIntegrationTest {
     @Test
     fun `canExchangeOBOToken - skal returnere true når ikke admin forespørsel og ingen token kontekst`() {
         val contextHolder = ContextHolder()
-
+        
         // Standard tilstand - ikke admin forespørsel, ingen token kontekst
-        assertThat(contextHolder.canExchangeOBOToken()).isFalse() // Returnerer false fordi getTokenContext() returnerer null
+        contextHolder.canExchangeOBOToken() shouldBe false // Returnerer false fordi getTokenContext() returnerer null
     }
 
     @Test
     fun `canExchangeOBOToken - skal returnere false under admin forespørsel`() {
         val contextHolder = ContextHolder()
-
+        
         ThreadLocalAccessInfo.utførSomAdminForespørsel {
             // Under admin forespørsel, skal bruke systemtoken (ikke OBO)
-            assertThat(contextHolder.canExchangeOBOToken()).isFalse()
+            contextHolder.canExchangeOBOToken() shouldBe false
         }
-
+        
         // Etter admin forespørsel, reset til normal tilstand
-        assertThat(contextHolder.canExchangeOBOToken()).isFalse() // Fortsatt false på grunn av ingen token kontekst
+        contextHolder.canExchangeOBOToken() shouldBe false // Fortsatt false på grunn av ingen token kontekst
     }
 
     @Test
     fun `token utvelgelse logikk - admin forespørsel skal bruke system token`() {
         // Simuler logikken som ville skje i interceptors
-
+        
         // Normal forespørsel
         val shouldUseSystemTokenNormal = ThreadLocalAccessInfo.skalBrukeSystemToken()
-        assertThat(shouldUseSystemTokenNormal).isFalse()
-
+        shouldUseSystemTokenNormal shouldBe false
+        
         // Admin forespørsel
         ThreadLocalAccessInfo.utførSomAdminForespørsel {
             val shouldUseSystemTokenAdmin = ThreadLocalAccessInfo.skalBrukeSystemToken()
-            assertThat(shouldUseSystemTokenAdmin).isTrue()
+            shouldUseSystemTokenAdmin shouldBe true
         }
-
+        
         // Reset til normal tilstand etter admin forespørsel
         val shouldUseSystemTokenAfter = ThreadLocalAccessInfo.skalBrukeSystemToken()
-        assertThat(shouldUseSystemTokenAfter).isFalse()
+        shouldUseSystemTokenAfter shouldBe false
     }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ContextHolderIntegrationTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ContextHolderIntegrationTest.kt
@@ -1,0 +1,47 @@
+package no.nav.melosys.eessi.security
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ContextHolderIntegrationTest {
+
+    @Test
+    fun `canExchangeOBOToken - skal returnere true når ikke admin forespørsel og ingen token kontekst`() {
+        val contextHolder = ContextHolder()
+
+        // Standard tilstand - ikke admin forespørsel, ingen token kontekst
+        assertThat(contextHolder.canExchangeOBOToken()).isFalse() // Returnerer false fordi getTokenContext() returnerer null
+    }
+
+    @Test
+    fun `canExchangeOBOToken - skal returnere false under admin forespørsel`() {
+        val contextHolder = ContextHolder()
+
+        ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            // Under admin forespørsel, skal bruke systemtoken (ikke OBO)
+            assertThat(contextHolder.canExchangeOBOToken()).isFalse()
+        }
+
+        // Etter admin forespørsel, reset til normal tilstand
+        assertThat(contextHolder.canExchangeOBOToken()).isFalse() // Fortsatt false på grunn av ingen token kontekst
+    }
+
+    @Test
+    fun `token utvelgelse logikk - admin forespørsel skal bruke system token`() {
+        // Simuler logikken som ville skje i interceptors
+
+        // Normal forespørsel
+        val shouldUseSystemTokenNormal = ThreadLocalAccessInfo.skalBrukeSystemToken()
+        assertThat(shouldUseSystemTokenNormal).isFalse()
+
+        // Admin forespørsel
+        ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            val shouldUseSystemTokenAdmin = ThreadLocalAccessInfo.skalBrukeSystemToken()
+            assertThat(shouldUseSystemTokenAdmin).isTrue()
+        }
+
+        // Reset til normal tilstand etter admin forespørsel
+        val shouldUseSystemTokenAfter = ThreadLocalAccessInfo.skalBrukeSystemToken()
+        assertThat(shouldUseSystemTokenAfter).isFalse()
+    }
+}

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfoTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfoTest.kt
@@ -1,0 +1,91 @@
+package no.nav.melosys.eessi.security
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ThreadLocalAccessInfoTest {
+
+    @Test
+    fun `skalBrukeSystemToken - standard tilstand skal returnere false`() {
+        // Standard tilstand skal ikke være admin-forespørsel
+        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+    }
+
+    @Test
+    fun `skalBrukeSystemToken - under admin-forespørsel utførelse skal returnere true`() {
+        var systemTokenBrukt = false
+        
+        ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            systemTokenBrukt = ThreadLocalAccessInfo.skalBrukeSystemToken()
+        }
+        
+        assertThat(systemTokenBrukt).isTrue()
+        // Etter utførelse skal det være tilbake til normalt
+        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+    }
+
+    @Test
+    fun `utførSomAdminForespørsel - skal utføre lambda og returnere resultat`() {
+        val resultat = ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            "test-resultat"
+        }
+        
+        assertThat(resultat).isEqualTo("test-resultat")
+    }
+
+    @Test
+    fun `utførSomAdminForespørsel - skal håndtere exceptions riktig`() {
+        val exception = assertThrows<RuntimeException> {
+            ThreadLocalAccessInfo.utførSomAdminForespørsel {
+                throw RuntimeException("Test exception")
+            }
+        }
+        
+        assertThat(exception.message).isEqualTo("Test exception")
+        // Skal være ryddet opp etter exception
+        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+    }
+
+    @Test
+    fun `utførSomAdminForespørsel - nestede kall skal fungere korrekt`() {
+        val resultater = mutableListOf<Boolean>()
+        
+        ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            resultater.add(ThreadLocalAccessInfo.skalBrukeSystemToken()) // Skal være true
+            
+            ThreadLocalAccessInfo.utførSomAdminForespørsel {
+                resultater.add(ThreadLocalAccessInfo.skalBrukeSystemToken()) // Skal fortsatt være true
+            }
+            
+            resultater.add(ThreadLocalAccessInfo.skalBrukeSystemToken()) // Skal fortsatt være true
+        }
+        
+        assertThat(resultater).containsExactly(true, true, true)
+        // Etter alle nestede kall skal det være tilbake til normalt
+        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+    }
+
+    @Test
+    fun `hentBrukerId - skal returnere null som standard`() {
+        assertThat(ThreadLocalAccessInfo.hentBrukerId()).isNull()
+    }
+
+    @Test
+    fun `hentInfo - skal returnere string-representasjon`() {
+        val info = ThreadLocalAccessInfo.hentInfo()
+        assertThat(info).contains("ThreadLocalAccessInfo")
+        assertThat(info).contains("erAdminForespørsel=false")
+    }
+
+    @Test
+    fun `hentInfo - under admin-forespørsel skal vise admin-tilstand`() {
+        var infoStreng = ""
+        
+        ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            infoStreng = ThreadLocalAccessInfo.hentInfo()
+        }
+        
+        assertThat(infoStreng).contains("erAdminForespørsel=true")
+    }
+} 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfoTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/security/ThreadLocalAccessInfoTest.kt
@@ -1,15 +1,17 @@
 package no.nav.melosys.eessi.security
 
-import org.assertj.core.api.Assertions.assertThat
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.assertions.throwables.shouldThrow
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class ThreadLocalAccessInfoTest {
 
     @Test
     fun `skalBrukeSystemToken - standard tilstand skal returnere false`() {
         // Standard tilstand skal ikke være admin-forespørsel
-        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+        ThreadLocalAccessInfo.skalBrukeSystemToken() shouldBe false
     }
 
     @Test
@@ -20,9 +22,9 @@ class ThreadLocalAccessInfoTest {
             systemTokenBrukt = ThreadLocalAccessInfo.skalBrukeSystemToken()
         }
         
-        assertThat(systemTokenBrukt).isTrue()
+        systemTokenBrukt shouldBe true
         // Etter utførelse skal det være tilbake til normalt
-        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+        ThreadLocalAccessInfo.skalBrukeSystemToken() shouldBe false
     }
 
     @Test
@@ -31,20 +33,20 @@ class ThreadLocalAccessInfoTest {
             "test-resultat"
         }
         
-        assertThat(resultat).isEqualTo("test-resultat")
+        resultat shouldBe "test-resultat"
     }
 
     @Test
     fun `utførSomAdminForespørsel - skal håndtere exceptions riktig`() {
-        val exception = assertThrows<RuntimeException> {
+        val exception = shouldThrow<RuntimeException> {
             ThreadLocalAccessInfo.utførSomAdminForespørsel {
                 throw RuntimeException("Test exception")
             }
         }
         
-        assertThat(exception.message).isEqualTo("Test exception")
+        exception.message shouldBe "Test exception"
         // Skal være ryddet opp etter exception
-        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+        ThreadLocalAccessInfo.skalBrukeSystemToken() shouldBe false
     }
 
     @Test
@@ -61,21 +63,21 @@ class ThreadLocalAccessInfoTest {
             resultater.add(ThreadLocalAccessInfo.skalBrukeSystemToken()) // Skal fortsatt være true
         }
         
-        assertThat(resultater).containsExactly(true, true, true)
+        resultater shouldContainExactly listOf(true, true, true)
         // Etter alle nestede kall skal det være tilbake til normalt
-        assertThat(ThreadLocalAccessInfo.skalBrukeSystemToken()).isFalse()
+        ThreadLocalAccessInfo.skalBrukeSystemToken() shouldBe false
     }
 
     @Test
     fun `hentBrukerId - skal returnere null som standard`() {
-        assertThat(ThreadLocalAccessInfo.hentBrukerId()).isNull()
+        ThreadLocalAccessInfo.hentBrukerId() shouldBe null
     }
 
     @Test
     fun `hentInfo - skal returnere string-representasjon`() {
         val info = ThreadLocalAccessInfo.hentInfo()
-        assertThat(info).contains("ThreadLocalAccessInfo")
-        assertThat(info).contains("erAdminForespørsel=false")
+        info shouldContain "ThreadLocalAccessInfo"
+        info shouldContain "erAdminForespørsel=false"
     }
 
     @Test
@@ -86,6 +88,6 @@ class ThreadLocalAccessInfoTest {
             infoStreng = ThreadLocalAccessInfo.hentInfo()
         }
         
-        assertThat(infoStreng).contains("erAdminForespørsel=true")
+        infoStreng shouldContain "erAdminForespørsel=true"
     }
 } 


### PR DESCRIPTION
EUX svarer med at vi ikke har tilgang til å gjøre diverse forespørsler. Det er pga OBO-tokens, og våre brukere som ikke har tilgang til Eux/Rina i prod. Derfor kjører vi admin-requests med systemtokens når vi konsumerer eksterne tjenester. Gjenbruker samme system som vi har i melosys-api.

Mulig vi burde få disse tilgangene på sikt, men det er noen grunner til at vi ikke gjør det nå.
- Det vil forsinke DLQs som er i prod i dag, ettersom vi ikke vet hvor lang tid tilgangene  vil ta.
- Det er ikke verre enn dagens løsning. Med forrige PR #733, har vi hatt stor forbedring.
- Gjennom melosys-console blir all historikk av forespørsler lagret for sporbarhet.
