### PR TITLE
VAKT Sjekker om HSED også er tom når ASED er tom før vi kaster feilmelding

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
@@ -245,7 +245,7 @@ public class EuxConsumer implements RestConsumer {
         } catch (RestClientException e) {
             try {
                 String appEnvironment = environment.getProperty("APP_ENVIRONMENT");
-                if (appEnvironment != null && appEnvironment.equals("devf")) {
+                if (appEnvironment != null && appEnvironment.equals("dev")) {
                     String value = objectMapper.writeValueAsString(entity.getBody());
                     log.info("Feil ved kall mot eux: {} sed:\n{}", e.getMessage(), value);
                 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/integration/eux/rina_api/EuxConsumer.java
@@ -245,7 +245,7 @@ public class EuxConsumer implements RestConsumer {
         } catch (RestClientException e) {
             try {
                 String appEnvironment = environment.getProperty("APP_ENVIRONMENT");
-                if (appEnvironment != null && appEnvironment.equals("dev")) {
+                if (appEnvironment != null && appEnvironment.equals("devf")) {
                     String value = objectMapper.writeValueAsString(entity.getBody());
                     log.info("Feil ved kall mot eux: {} sed:\n{}", e.getMessage(), value);
                 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/JournalpostSedKobling.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/JournalpostSedKobling.kt
@@ -28,4 +28,8 @@ class JournalpostSedKobling(
     fun erASed(): Boolean {
         return sedType.uppercase().startsWith("A")
     }
+
+    fun erHSed(): Boolean {
+        return sedType.uppercase().startsWith("H")
+    }
 }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingService.kt
@@ -42,6 +42,9 @@ class JournalpostSedKoblingService(
     fun erASedAlleredeBehandlet(rinaSaksnummer: String): Boolean =
         journalpostSedKoblingRepository.findByRinaSaksnummer(rinaSaksnummer).any { it.erASed() }
 
+    fun erHSedAlleredeBehandlet(rinaSaksnummer: String): Boolean =
+        journalpostSedKoblingRepository.findByRinaSaksnummer(rinaSaksnummer).any { it.erHSed() }
+
     fun lagre(
         journalpostID: String,
         rinaSaksnummer: String,

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
@@ -64,7 +64,7 @@ class SedMottakService(
             return
         }
 
-        check(!erXSedBehandletUtenASed(sedMottattHendelse.sedHendelse)) {
+        check(!erXSedBehandletUtenASedEllerHSed(sedMottattHendelse.sedHendelse)) {
             "Mottatt SED ${sedMottattHendelse.sedHendelse.sedId} av type ${
                 sedMottattHendelse.sedHendelse.sedType
             } har ikke tilhørende A sed behandlet"
@@ -125,7 +125,7 @@ class SedMottakService(
         }
     }
 
-    private fun erXSedBehandletUtenASed(sedHendelse: SedHendelse): Boolean {
+    private fun erXSedBehandletUtenASedEllerHSed(sedHendelse: SedHendelse): Boolean {
         if (!sedHendelse.erXSedSomTrengerKontroll()) return false
 
         if (sedHendelse.sedType == SedType.X007.name) {
@@ -139,15 +139,15 @@ class SedMottakService(
             if (sedTypeErX007OgNorgeErSakseier) return false
         }
 
-        val aSed = sedMottattHendelseRepository.findAllByRinaSaksnummerSortedByMottattDatoDesc(
+        val sed = sedMottattHendelseRepository.findAllByRinaSaksnummerSortedByMottattDatoDesc(
             sedHendelse.rinaSakId
         ).singleOrNull()
 
-        if (aSed?.skalJournalfoeres == false) {
+        if (sed?.skalJournalfoeres == false) {
             return false
         }
 
-        return !journalpostSedKoblingService.erASedAlleredeBehandlet(sedHendelse.rinaSakId)
+        return !(journalpostSedKoblingService.erASedAlleredeBehandlet(sedHendelse.rinaSakId) || journalpostSedKoblingService.erHSedAlleredeBehandlet(sedHendelse.rinaSakId))
     }
 
     private fun opprettOppgaveIdentifisering(sedMottatt: SedMottattHendelse, sed: SED) {


### PR DESCRIPTION
https://nav-it.slack.com/archives/CPSMP2GKT/p1753168967881179

Dette er en sak som er opprettet i forbindelse med en vakt sak der vi kaster feilmelding på en X-SED som ikke har A-SED men har H-SED. Dette blir ikke helt riktig. Har derfor lagt til ekstra kode for å sjekke H-SED i tillegg.

Har også endret variabel navn fra `aSed` til `sed` da jeg er litt usikker det faktisk er A-SED som blir sjekket siden det ikke finnes noe som tyder på det i metodene. Men jeg kan fort ta feil her. 