### PR TITLE
VAKT Admin endepunkt for Oppdatering av gsaknummer

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/SaksrelasjonAdminTjeneste.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/SaksrelasjonAdminTjeneste.kt
@@ -1,0 +1,42 @@
+package no.nav.melosys.eessi.controller
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import no.nav.melosys.eessi.controller.dto.OppdaterGsakSaksnummerDto
+import no.nav.melosys.eessi.service.saksrelasjon.SaksrelasjonAdminService
+import no.nav.security.token.support.core.api.Protected
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Protected
+@RestController
+@RequestMapping("/admin/saksrelasjon")
+class SaksrelasjonAdminTjeneste(
+    @Value("\${melosys.admin.api-key}") private val apiKey: String,
+    private val saksrelasjonAdminService: SaksrelasjonAdminService
+) {
+
+    @PutMapping("/gsaknummer")
+    @ApiResponse(description = "Oppdaterer gsakSaksnummer for en gitt rinaSaksnummer")
+    fun oppdaterGsakSaksnummer(
+        @RequestHeader(API_KEY_HEADER) apiKey: String,
+        @RequestBody request: OppdaterGsakSaksnummerDto
+    ): ResponseEntity<String> {
+        
+        validerApikey(apiKey)
+        
+        saksrelasjonAdminService.oppdaterGsakSaksnummer(request.rinaSaksnummer, request.nyGsakSaksnummer)
+        
+        return ResponseEntity.ok("Gsaknummer oppdatert for rinaSaksnummer: ${request.rinaSaksnummer}")
+    }
+
+    private fun validerApikey(value: String) {
+        if (apiKey != value) {
+            throw SecurityException("Ugyldig API-nøkkel")
+        }
+    }
+
+    companion object {
+        private const val API_KEY_HEADER = "X-MELOSYS-ADMIN-APIKEY"
+    }
+}

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/OppdaterGsakSaksnummerDto.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/dto/OppdaterGsakSaksnummerDto.kt
@@ -1,0 +1,6 @@
+package no.nav.melosys.eessi.controller.dto
+
+data class OppdaterGsakSaksnummerDto(
+    val rinaSaksnummer: String,
+    val nyGsakSaksnummer: Long
+)

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonAdminService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/saksrelasjon/SaksrelasjonAdminService.kt
@@ -1,0 +1,43 @@
+package no.nav.melosys.eessi.service.saksrelasjon
+
+import mu.KotlinLogging
+import no.nav.melosys.eessi.models.exception.ValidationException
+import no.nav.melosys.eessi.repository.FagsakRinasakKoblingRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.util.StringUtils
+
+private val log = KotlinLogging.logger {}
+
+@Service
+class SaksrelasjonAdminService(
+    private val fagsakRinasakKoblingRepository: FagsakRinasakKoblingRepository
+) {
+
+    @Transactional
+    fun oppdaterGsakSaksnummer(rinaSaksnummer: String, nyGsakSaksnummer: Long) {
+        validerInput(rinaSaksnummer, nyGsakSaksnummer)
+
+        val eksisterendeKobling = fagsakRinasakKoblingRepository.findByRinaSaksnummer(rinaSaksnummer)
+            .orElseThrow { ValidationException("Fant ikke rinaSaksnummer: $rinaSaksnummer") }
+
+        val gammelGsakSaksnummer = eksisterendeKobling.gsakSaksnummer
+
+        log.info { "Oppdaterer gsakSaksnummer for rinaSaksnummer $rinaSaksnummer fra $gammelGsakSaksnummer til $nyGsakSaksnummer" }
+
+        eksisterendeKobling.gsakSaksnummer = nyGsakSaksnummer
+        fagsakRinasakKoblingRepository.save(eksisterendeKobling)
+
+        log.info { "Oppdatert gsakSaksnummer for rinaSaksnummer $rinaSaksnummer fra $gammelGsakSaksnummer til $nyGsakSaksnummer" }
+    }
+
+    private fun validerInput(rinaSaksnummer: String, nyGsakSaksnummer: Long) {
+        if (!StringUtils.hasText(rinaSaksnummer)) {
+            throw ValidationException("rinaSaksnummer kan ikke være tom")
+        }
+
+        if (nyGsakSaksnummer < 1L) {
+            throw ValidationException("nyGsakSaksnummer må være større enn 0")
+        }
+    }
+}


### PR DESCRIPTION
Lager raskt ett admin endepunkt for Oppdatering av Gsaknummer for saksrelasjon. Vi kan ikke bruke fagsak direkte i melosys-eessi.
Jeg har ikke fått testa dette i q2 enda.