### PR TITLE
7736 G4P Dependency cooldown i Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       minor-and-patch:
         update-types:
@@ -16,4 +18,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
- Lagt til cooldown.default-days: 7 for npm og github-actions   - Endret github-actions fra daily til weekly schedule
- Beskytter mot supply chain-angrep ved å vente på at nye versjoner "modnes" før de tilbys som oppdateringer