### PR TITLE
8011 Fikser ASED fallback for å forhindre dlq feil

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingService.kt
@@ -29,6 +29,10 @@ class JournalpostSedKoblingService(
     fun finnVedJournalpostID(journalpostID: String): Optional<JournalpostSedKobling> =
         journalpostSedKoblingRepository.findByJournalpostID(journalpostID)
 
+    fun harASedEllerHSedForRinaSak(rinaSaksnummer: String): Boolean =
+        journalpostSedKoblingRepository.findByRinaSaksnummer(rinaSaksnummer)
+            .any { it.erASed() || it.erHSed() }
+
     fun finnVedJournalpostIDOpprettMelosysEessiMelding(journalpostID: String): Optional<MelosysEessiMelding> {
         val journalpostSedKobling = journalpostSedKoblingRepository.findByJournalpostID(journalpostID).getOrNull()
         return Optional.ofNullable(

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
@@ -171,21 +171,25 @@ class SedMottakService(
             return false
         }
 
-        log.info("Fant ingen tilhørende A-SED/H-SED i sed_mottatt_hendelse for rinaSakId ${sedHendelse.rinaSakId} (${sedHendelser.size} hendelser funnet)")
+        log.info("Fant ingen tilhørende A-SED/H-SED i sed_mottatt_hendelse for rinaSakId ${sedHendelse.rinaSakId}. Sjekker journalpost_sed_kobling.")
 
-        // Fallback for X001: sjekk journalpost_sed_kobling for historiske data (før DB-bytte)
-        if (sedHendelse.sedType == SedType.X001.name) {
-            log.info("X001 ${sedHendelse.sedId}: sjekker fallback mot journalpost_sed_kobling for rinaSakId ${sedHendelse.rinaSakId}")
-            val harASedEllerHSedIJournalpostKobling = journalpostSedKoblingService.harASedEllerHSedForRinaSak(sedHendelse.rinaSakId)
-            if (harASedEllerHSedIJournalpostKobling) {
-                log.info("X001 ${sedHendelse.sedId}: fant tilhørende A-SED/H-SED i journalpost_sed_kobling (fallback) for rinaSakId ${sedHendelse.rinaSakId}")
-                return false
-            }
-            log.info("X001 ${sedHendelse.sedId}: fant ingen tilhørende A-SED/H-SED i journalpost_sed_kobling for rinaSakId ${sedHendelse.rinaSakId}")
-        }
+        if (harASedEllerHSedIJournalpostKobling(sedHendelse)) return false
 
         log.warn("X-SED ${sedHendelse.sedId} av type ${sedHendelse.sedType}: ingen tilhørende A-SED/H-SED funnet for rinaSakId ${sedHendelse.rinaSakId}")
         return true
+    }
+
+    private fun harASedEllerHSedIJournalpostKobling(sedHendelse: SedHendelse): Boolean {
+        if (sedHendelse.sedType != SedType.X001.name) return false
+
+        log.info("X001 ${sedHendelse.sedId}: sjekker fallback mot journalpost_sed_kobling for rinaSakId ${sedHendelse.rinaSakId}")
+        val funnet = journalpostSedKoblingService.harASedEllerHSedForRinaSak(sedHendelse.rinaSakId)
+        if (funnet) {
+            log.info("X001 ${sedHendelse.sedId}: fant tilhørende A-SED/H-SED i journalpost_sed_kobling (fallback) for rinaSakId ${sedHendelse.rinaSakId}")
+        } else {
+            log.info("X001 ${sedHendelse.sedId}: fant ingen tilhørende A-SED/H-SED i journalpost_sed_kobling for rinaSakId ${sedHendelse.rinaSakId}")
+        }
+        return funnet
     }
 
     private fun opprettOppgaveIdentifisering(sedMottatt: SedMottattHendelse, sed: SED) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
@@ -156,9 +156,22 @@ class SedMottakService(
         }
 
         val sedHendelser = sedMottattHendelseRepository.findAllByRinaSaksnummerSortedByMottattDatoDesc(sedHendelse.rinaSakId)
-        return !(sedHendelser.any {
+        val harASedEllerHSedIMottattHendelse = sedHendelser.any {
             it.sedHendelse.erASED() || it.sedHendelse.erHSED()
-        })
+        }
+
+        if (harASedEllerHSedIMottattHendelse) return false
+
+        // Fallback for X001: sjekk journalpost_sed_kobling for historiske data (før DB-bytte)
+        if (sedHendelse.sedType == SedType.X001.name) {
+            val harASedEllerHSedIJournalpostKobling = journalpostSedKoblingService.harASedEllerHSedForRinaSak(sedHendelse.rinaSakId)
+            if (harASedEllerHSedIJournalpostKobling) {
+                log.info("Fant tilhørende A-SED/H-SED i journalpost_sed_kobling (fallback) for rinaSakId ${sedHendelse.rinaSakId}")
+                return false
+            }
+        }
+
+        return true
     }
 
     private fun opprettOppgaveIdentifisering(sedMottatt: SedMottattHendelse, sed: SED) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/mottak/SedMottakService.kt
@@ -49,31 +49,32 @@ class SedMottakService(
 
     @Transactional
     fun behandleSedMottakHendelse(sedMottattHendelse: SedMottattHendelse) {
-        if (sedMottattHendelse.sedHendelse.erIkkeLaBuc() && !erHBucFraMelosys(sedMottattHendelse)) {
-            log.debug("Ignorerer mottatt SED ${sedMottattHendelse.sedHendelse.sedId} BUC type ikke tilknyttet melosys")
+        val sedHendelse = sedMottattHendelse.sedHendelse
+        log.info("Behandler mottatt SED ${sedHendelse.sedId} av type ${sedHendelse.sedType} i rinaSak ${sedHendelse.rinaSakId}")
+
+        if (sedHendelse.erIkkeLaBuc() && !erHBucFraMelosys(sedMottattHendelse)) {
+            log.debug("Ignorerer mottatt SED ${sedHendelse.sedId} BUC type ikke tilknyttet melosys")
             return
         }
 
-        if (sedMottattHendelse.sedHendelse.erX100()) {
-            log.info("Ignorerer mottatt SED ${sedMottattHendelse.sedHendelse.sedId} av typen X100")
+        if (sedHendelse.erX100()) {
+            log.info("Ignorerer mottatt SED ${sedHendelse.sedId} av typen X100")
             return
         }
 
-        if (sedMottattHendelseRepository.findBySedID(sedMottattHendelse.sedHendelse.sedId).isPresent) {
-            log.info("Mottatt SED ${sedMottattHendelse.sedHendelse.sedId} er allerede behandlet")
+        if (sedMottattHendelseRepository.findBySedID(sedHendelse.sedId).isPresent) {
+            log.info("Mottatt SED ${sedHendelse.sedId} er allerede behandlet")
             return
         }
 
-        val erXSedBehandletUtenASedEllerHSed = erXSedBehandletUtenASedEllerHSed(sedMottattHendelse.sedHendelse)
+        val erXSedBehandletUtenASedEllerHSed = erXSedBehandletUtenASedEllerHSed(sedHendelse)
 
         check(!erXSedBehandletUtenASedEllerHSed) {
-            "Mottatt SED ${sedMottattHendelse.sedHendelse.sedId} av type ${
-                sedMottattHendelse.sedHendelse.sedType
-            } har ikke tilhørende A sed behandlet"
+            "Mottatt SED ${sedHendelse.sedId} av type ${sedHendelse.sedType} har ikke tilhørende A sed behandlet"
         }
 
-        sjekkSedMottakerOgAvsenderID(sedMottattHendelse.sedHendelse)
-        sjekkSedMottakerOgAvsenderNavn(sedMottattHendelse.sedHendelse)
+        sjekkSedMottakerOgAvsenderID(sedHendelse)
+        sjekkSedMottakerOgAvsenderNavn(sedHendelse)
 
         if (SedType.valueOf(sedMottattHendelse.sedHendelse.sedType).erXSED()) {
             val initiellSed = sedMottattHendelseRepository.findAllByRinaSaksnummerSortedByMottattDatoDesc(
@@ -144,6 +145,8 @@ class SedMottakService(
     private fun erXSedBehandletUtenASedEllerHSed(sedHendelse: SedHendelse): Boolean {
         if (!sedHendelse.erXSedSomTrengerKontroll()) return false
 
+        log.info("X-SED ${sedHendelse.sedId} av type ${sedHendelse.sedType} trenger kontroll, sjekker om tilhørende A-SED/H-SED finnes for rinaSakId ${sedHendelse.rinaSakId}")
+
         if (sedHendelse.sedType == SedType.X007.name) {
             val buc = euxService.hentBuc(sedHendelse.rinaSakId)
 
@@ -152,7 +155,10 @@ class SedMottakService(
                     && p.organisation!!.id == rinaInstitusjonsId
             }
 
-            if (sedTypeErX007OgNorgeErSakseier) return false
+            if (sedTypeErX007OgNorgeErSakseier) {
+                log.info("X007 ${sedHendelse.sedId}: Norge er sakseier, hopper over A-SED/H-SED-sjekk")
+                return false
+            }
         }
 
         val sedHendelser = sedMottattHendelseRepository.findAllByRinaSaksnummerSortedByMottattDatoDesc(sedHendelse.rinaSakId)
@@ -160,17 +166,25 @@ class SedMottakService(
             it.sedHendelse.erASED() || it.sedHendelse.erHSED()
         }
 
-        if (harASedEllerHSedIMottattHendelse) return false
+        if (harASedEllerHSedIMottattHendelse) {
+            log.info("Fant tilhørende A-SED/H-SED i sed_mottatt_hendelse for rinaSakId ${sedHendelse.rinaSakId}")
+            return false
+        }
+
+        log.info("Fant ingen tilhørende A-SED/H-SED i sed_mottatt_hendelse for rinaSakId ${sedHendelse.rinaSakId} (${sedHendelser.size} hendelser funnet)")
 
         // Fallback for X001: sjekk journalpost_sed_kobling for historiske data (før DB-bytte)
         if (sedHendelse.sedType == SedType.X001.name) {
+            log.info("X001 ${sedHendelse.sedId}: sjekker fallback mot journalpost_sed_kobling for rinaSakId ${sedHendelse.rinaSakId}")
             val harASedEllerHSedIJournalpostKobling = journalpostSedKoblingService.harASedEllerHSedForRinaSak(sedHendelse.rinaSakId)
             if (harASedEllerHSedIJournalpostKobling) {
-                log.info("Fant tilhørende A-SED/H-SED i journalpost_sed_kobling (fallback) for rinaSakId ${sedHendelse.rinaSakId}")
+                log.info("X001 ${sedHendelse.sedId}: fant tilhørende A-SED/H-SED i journalpost_sed_kobling (fallback) for rinaSakId ${sedHendelse.rinaSakId}")
                 return false
             }
+            log.info("X001 ${sedHendelse.sedId}: fant ingen tilhørende A-SED/H-SED i journalpost_sed_kobling for rinaSakId ${sedHendelse.rinaSakId}")
         }
 
+        log.warn("X-SED ${sedHendelse.sedId} av type ${sedHendelse.sedType}: ingen tilhørende A-SED/H-SED funnet for rinaSakId ${sedHendelse.rinaSakId}")
         return true
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingServiceTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/journalpostkobling/JournalpostSedKoblingServiceTest.kt
@@ -84,4 +84,38 @@ class JournalpostSedKoblingServiceTest {
                 .avsenderID shouldBe "mnb"
         }
     }
+
+    @Test
+    fun `harASedEllerHSedForRinaSak returnerer true når A-SED finnes`() {
+        every { journalpostSedKoblingRepository.findByRinaSaksnummer("123") } returns mutableListOf(
+            JournalpostSedKobling("jp1", "123", "sedId1", "1", "LA_BUC_02", "A009")
+        )
+
+        journalpostSedKoblingService.harASedEllerHSedForRinaSak("123") shouldBe true
+    }
+
+    @Test
+    fun `harASedEllerHSedForRinaSak returnerer true når H-SED finnes`() {
+        every { journalpostSedKoblingRepository.findByRinaSaksnummer("123") } returns mutableListOf(
+            JournalpostSedKobling("jp1", "123", "sedId1", "1", "H_BUC_01", "H001")
+        )
+
+        journalpostSedKoblingService.harASedEllerHSedForRinaSak("123") shouldBe true
+    }
+
+    @Test
+    fun `harASedEllerHSedForRinaSak returnerer false når kun X-SED finnes`() {
+        every { journalpostSedKoblingRepository.findByRinaSaksnummer("123") } returns mutableListOf(
+            JournalpostSedKobling("jp1", "123", "sedId1", "1", "LA_BUC_02", "X001")
+        )
+
+        journalpostSedKoblingService.harASedEllerHSedForRinaSak("123") shouldBe false
+    }
+
+    @Test
+    fun `harASedEllerHSedForRinaSak returnerer false når ingen koblinger finnes`() {
+        every { journalpostSedKoblingRepository.findByRinaSaksnummer("123") } returns mutableListOf()
+
+        journalpostSedKoblingService.harASedEllerHSedForRinaSak("123") shouldBe false
+    }
 }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/mottak/SedMottakServiceTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/mottak/SedMottakServiceTest.kt
@@ -237,6 +237,38 @@ class SedMottakServiceTest {
     }
 
     @Test
+    fun `behandle SED - X001 uten A-SED i sed_mottatt_hendelse men med A-SED i journalpost_sed_kobling kaster ikke exception`() {
+        val sedHendelse = sedHendelseMedBruker().apply { sedType = "X001" }
+        val sedMottattHendelse = SedMottattHendelse.builder().sedHendelse(sedHendelse).build()
+
+        every { sedMottattHendelseRepository.findAllByRinaSaksnummerSortedByMottattDatoDesc(any()) } returns emptyList()
+        every { journalpostSedKoblingService.harASedEllerHSedForRinaSak(RINA_SAKSNUMMER) } returns true
+        every { euxService.hentSedMedRetry(any(), any()) } returns opprettSED()
+        every { personIdentifisering.identifiserPerson(any(), any()) } returns Optional.of(IDENT)
+        every { sedMottattHendelseRepository.save(any<SedMottattHendelse>()) } returnsArgument 0
+
+        shouldNotThrow<IllegalStateException> {
+            sedMottakService.behandleSedMottakHendelse(sedMottattHendelse)
+        }
+
+        verify { journalpostSedKoblingService.harASedEllerHSedForRinaSak(RINA_SAKSNUMMER) }
+        verify { euxService.hentSedMedRetry(any(), any()) }
+    }
+
+    @Test
+    fun `behandle SED - X001 uten A-SED i begge tabeller kaster exception`() {
+        val sedHendelse = sedHendelseMedBruker().apply { sedType = "X001" }
+        val sedMottattHendelse = SedMottattHendelse.builder().sedHendelse(sedHendelse).build()
+
+        every { sedMottattHendelseRepository.findAllByRinaSaksnummerSortedByMottattDatoDesc(any()) } returns emptyList()
+        every { journalpostSedKoblingService.harASedEllerHSedForRinaSak(RINA_SAKSNUMMER) } returns false
+
+        shouldThrow<IllegalStateException> {
+            sedMottakService.behandleSedMottakHendelse(sedMottattHendelse)
+        }.message shouldBe "Mottatt SED 555554444 av type X001 har ikke tilhørende A sed behandlet"
+    }
+
+    @Test
     fun `behandle SED - X-SED med bare H-SED og ikke A-SED skal ikke kaste exception`() {
         val sedHendelse = sedHendelseMedBruker().apply { sedType = "X008" }
         val sedMottattHendelse = SedMottattHendelse.builder().sedHendelse(sedHendelse).build()


### PR DESCRIPTION
Legger til fallback-sjekk mot journalpost_sed_kobling-tabellen for X001 SED-er som mangler tilhørende A-SED i sed_mottatt_hendelse.

Polen har sendt over 1000 X-SED-er i forbindelse med en opprydnings-/lukkejobb.
Etter DB-bytte mangler gamle A-SED-er i sed_mottatt_hendelse-tabellen, noe som fører til at
X001-mottaket feiler med "har ikke tilhørende A sed behandlet" og havner i Kafka DLQ.
journalpost_sed_kobling har mer komplett historikk og brukes nå som fallback for X001.
[MELOSYS-8011](https://jira.adeo.no/browse/MELOSYS-8011)

- Ny metode `harASedEllerHSedForRinaSak` i JournalpostSedKoblingService for oppslag mot journalpost_sed_kobling
- Fallback-sjekk i `erXSedBehandletUtenASedEllerHSed` for X001 når A-SED/H-SED ikke finnes i sed_mottatt_hendelse
- Utvidet logging gjennom hele X-SED-kontrollsjekken for sporbarhet
- 5 nye enhetstester for fallback-scenariene

## Testing
- [x] Enhetstester (30 tester, 0 feil)
- [ ] Manuell testing lokalt
- [ ] Verifisering i dev mot DLQ-meldinger