### PR TITLE
7682 Hopp over SED-opprettelse hvis SED allerede er sendt

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.kt
@@ -48,7 +48,9 @@ data class BUC (
         finnDokumenterVedSedType(sedType).minWithOrNull(Comparator.comparing { document: Document -> SedStatus.fraEngelskStatus(document.status) ?: SedStatus.TOM })
 
     fun finnUtgåendeDokumentVedSedType(sedType: String): Document? =
-        documents.firstOrNull { it.type == sedType && !it.erInngående() && it.erOpprettet() }
+        documents.filter { it.type == sedType && !it.erInngående() && it.erOpprettet() }
+            .sortedBy { SedStatus.fraEngelskStatus(it.status)?.ordinal ?: Int.MAX_VALUE }
+            .firstOrNull()
 
     fun sedKanOppdateres(id: String): Boolean = actions.filter { id == it.documentId }
         .any { "Update".equals(it.operation, ignoreCase = true) }

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/models/buc/BUC.kt
@@ -47,6 +47,9 @@ data class BUC (
     fun finnDokumentVedSedType(sedType: String): Document? =
         finnDokumenterVedSedType(sedType).minWithOrNull(Comparator.comparing { document: Document -> SedStatus.fraEngelskStatus(document.status) ?: SedStatus.TOM })
 
+    fun finnUtgåendeDokumentVedSedType(sedType: String): Document? =
+        documents.firstOrNull { it.type == sedType && !it.erInngående() && it.erOpprettet() }
+
     fun sedKanOppdateres(id: String): Boolean = actions.filter { id == it.documentId }
         .any { "Update".equals(it.operation, ignoreCase = true) }
 

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/sed/SedService.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import no.nav.melosys.eessi.controller.dto.BucOgSedOpprettetDto
 import no.nav.melosys.eessi.controller.dto.SedDataDto
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.SedJournalstatus
+import no.nav.melosys.eessi.controller.dto.SedStatus
 import no.nav.melosys.eessi.models.BucType
 import no.nav.melosys.eessi.models.FagsakRinasakKobling
 import no.nav.melosys.eessi.models.SedType
@@ -172,8 +173,49 @@ class SedService(
         val sed = sedMapperFactory.mapTilSed(sedType, sedDataDto)
         verifiserSedVersjonErBucVersjon(buc, sed)
 
+        if (håndterEksisterendeSed(buc, rinaSaksnummer, sedType, sedDataDto, sed)) return
+
         return executeWithSedLogging("Feil ved sendPåEksisterendeBuc", sedDataDto, sed) {
             euxService.opprettOgSendSed(sed, rinaSaksnummer)
+        }
+    }
+
+    /**
+     * Sjekker om det allerede finnes en utgående SED av riktig type i BUCen.
+     * Returnerer true hvis situasjonen er håndtert (SED allerede sendt, eller utkast sendt),
+     * false hvis vi skal fortsette med å opprette ny SED.
+     */
+    private fun håndterEksisterendeSed(
+        buc: BUC, rinaSaksnummer: String, sedType: SedType, sedDataDto: SedDataDto, sed: SED
+    ): Boolean {
+        val eksisterendeSed = buc.finnUtgåendeDokumentVedSedType(sedType.name) ?: return false
+        val status = SedStatus.fraEngelskStatus(eksisterendeSed.status)
+
+        when (status) {
+            SedStatus.SENDT -> {
+                log.info(
+                    "SED {} av type {} er allerede sendt i rinasak {}. Hopper over opprettelse og sending.",
+                    eksisterendeSed.id, sedType, rinaSaksnummer
+                )
+                return true
+            }
+            SedStatus.UTKAST -> {
+                log.info(
+                    "SED {} av type {} finnes som utkast i rinasak {}. Sender eksisterende utkast.",
+                    eksisterendeSed.id, sedType, rinaSaksnummer
+                )
+                executeWithSedLogging("Feil ved sending av eksisterende utkast", sedDataDto, sed) {
+                    euxService.sendSed(rinaSaksnummer, eksisterendeSed.id, sedType.name)
+                }
+                return true
+            }
+            else -> {
+                log.info(
+                    "SED {} av type {} finnes med status {} i rinasak {}. Oppretter og sender ny.",
+                    eksisterendeSed.id, sedType, status, rinaSaksnummer
+                )
+                return false
+            }
         }
     }
 

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/sed/SedServiceTest.kt
@@ -351,6 +351,72 @@ class SedServiceTest {
     }
 
     @Test
+    fun `sendPåEksisterendeBuc - SED allerede sendt, hopper over opprettelse`() {
+        val buc = BUC(
+            bucVersjon = "v4.1",
+            documents = listOf(
+                Document(id = "sed-123", type = SedType.A012.name, status = "sent", direction = "OUT")
+            ),
+            actions = listOf(
+                Action("A012", "A012", "222", "Create")
+            )
+        )
+
+        every { euxService.hentBuc(any()) } returns buc
+
+        val sedDataDto = SedDataStub.getStub()
+        sendSedService.sendPåEksisterendeBuc(sedDataDto, "123", SedType.A012)
+
+        verify { euxService.hentBuc(any()) }
+        verify(exactly = 0) { euxService.opprettOgSendSed(any(), any()) }
+        verify(exactly = 0) { euxService.sendSed(any(), any(), any()) }
+    }
+
+    @Test
+    fun `sendPåEksisterendeBuc - SED finnes som utkast, sender eksisterende`() {
+        val buc = BUC(
+            bucVersjon = "v4.1",
+            documents = listOf(
+                Document(id = "sed-456", type = SedType.A011.name, status = "new", direction = "OUT")
+            ),
+            actions = listOf(
+                Action("A011", "A011", "222", "Create")
+            )
+        )
+
+        every { euxService.hentBuc(any()) } returns buc
+        every { euxService.sendSed(any(), any(), any()) } returns Unit
+
+        val sedDataDto = SedDataStub.getStub()
+        sendSedService.sendPåEksisterendeBuc(sedDataDto, "123", SedType.A011)
+
+        verify { euxService.hentBuc(any()) }
+        verify(exactly = 0) { euxService.opprettOgSendSed(any(), any()) }
+        verify { euxService.sendSed("123", "sed-456", SedType.A011.name) }
+    }
+
+    @Test
+    fun `sendPåEksisterendeBuc - innkommende SED av samme type ignoreres, oppretter ny`() {
+        val buc = BUC(
+            bucVersjon = "v4.1",
+            documents = listOf(
+                Document(id = "sed-789", type = SedType.A012.name, status = "received", direction = "IN")
+            ),
+            actions = listOf(
+                Action("A012", "A012", "222", "Create")
+            )
+        )
+
+        every { euxService.hentBuc(any()) } returns buc
+        every { euxService.opprettOgSendSed(any(), any()) } returns Unit
+
+        val sedDataDto = SedDataStub.getStub()
+        sendSedService.sendPåEksisterendeBuc(sedDataDto, "123", SedType.A012)
+
+        verify { euxService.opprettOgSendSed(any(), any()) }
+    }
+
+    @Test
     fun `genererPdfFraSed, forvent kall`() {
         val sedDataDto = SedDataStub.getStub()
         val mockPdf = "vi later som om dette er en pdf".toByteArray()


### PR DESCRIPTION
Legger til sjekk i sendPåEksisterendeBuc som håndterer tilfeller der en utgående SED allerede finnes i BUCen.

Unngår duplikate SED-er i RINA ved å sjekke status på eksisterende dokumenter før vi oppretter nye. Hvis en SED allerede er sendt hoppes steget over, og hvis den finnes som utkast sendes den eksisterende i stedet for å opprette ny.
[MELOSYS-7682](https://jira.adeo.no/browse/MELOSYS-7682)

- Ny funksjon `finnUtgåendeDokumentVedSedType` i BUC for å finne utgående dokumenter
- Ny metode `håndterEksisterendeSed` i SedService som sjekker status og håndterer allerede sendt/utkast
- 3 nye enhetstester for de ulike scenariene

## Testing
- [x] Enhetstester
- [x] Testing med Jonas i Q2