### PR TITLE
8127 G4P Legg til endepunkt for sletting av feilet Kafka-melding

### DIFF
--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KafkaDLQAdminTjeneste.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KafkaDLQAdminTjeneste.kt
@@ -48,6 +48,19 @@ class KafkaDLQAdminTjeneste(
         }
     }
 
+    @Operation(
+        summary = "Slett feilet Kafka-melding",
+        description = "Sletter en feilet melding fra DLQ uten å prosessere den. Brukes for meldinger som aldri skal prosesseres, f.eks. SED med ugyldig kombinasjon av BUC og SED."
+    )
+    @DeleteMapping("/{uuid}")
+    fun slettKafkaMelding(@PathVariable uuid: String, @RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<Void> {
+        validerApikey(apiKey)
+        return ThreadLocalAccessInfo.utførSomAdminForespørsel {
+            kafkaDLQService.slettKafkaMelding(UUID.fromString(uuid))
+            ResponseEntity.noContent().build()
+        }
+    }
+
     @PostMapping("/restart/alle")
     fun rekjørAlleKafkaMeldinger(@RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<Map<String, Any>> {
         validerApikey(apiKey)

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KafkaDLQAdminTjeneste.kt
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/controller/KafkaDLQAdminTjeneste.kt
@@ -1,11 +1,14 @@
 package no.nav.melosys.eessi.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import mu.KotlinLogging
 import no.nav.melosys.eessi.controller.dto.KafkaDLQDto
 import no.nav.melosys.eessi.controller.dto.ResendSedListeDto
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.v3.RinaSakOversiktV3
 import no.nav.melosys.eessi.integration.eux.rina_api.dto.v3.SedAnalyseResult
+import no.nav.melosys.eessi.models.exception.ValidationException
 import no.nav.melosys.eessi.models.kafkadlq.KafkaDLQ
 import no.nav.melosys.eessi.models.kafkadlq.SedMottattHendelseKafkaDLQ
 import no.nav.melosys.eessi.security.ThreadLocalAccessInfo
@@ -43,7 +46,7 @@ class KafkaDLQAdminTjeneste(
     fun rekjørKafkaMelding(@PathVariable uuid: String, @RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<Void> {
         validerApikey(apiKey)
         return ThreadLocalAccessInfo.utførSomAdminForespørsel {
-            kafkaDLQService.rekjørKafkaMelding(UUID.fromString(uuid))
+            kafkaDLQService.rekjørKafkaMelding(parseUuid(uuid))
             ResponseEntity.ok().build()
         }
     }
@@ -52,11 +55,18 @@ class KafkaDLQAdminTjeneste(
         summary = "Slett feilet Kafka-melding",
         description = "Sletter en feilet melding fra DLQ uten å prosessere den. Brukes for meldinger som aldri skal prosesseres, f.eks. SED med ugyldig kombinasjon av BUC og SED."
     )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "Meldingen ble slettet"),
+            ApiResponse(responseCode = "404", description = "Fant ingen KafkaDLQ-melding med angitt uuid"),
+            ApiResponse(responseCode = "400", description = "Ugyldig uuid")
+        ]
+    )
     @DeleteMapping("/{uuid}")
     fun slettKafkaMelding(@PathVariable uuid: String, @RequestHeader(API_KEY_HEADER) apiKey: String): ResponseEntity<Void> {
         validerApikey(apiKey)
         return ThreadLocalAccessInfo.utførSomAdminForespørsel {
-            kafkaDLQService.slettKafkaMelding(UUID.fromString(uuid))
+            kafkaDLQService.slettKafkaMelding(parseUuid(uuid))
             ResponseEntity.noContent().build()
         }
     }
@@ -201,6 +211,13 @@ class KafkaDLQAdminTjeneste(
             throw SecurityException("Ugyldig API-nøkkel")
         }
     }
+
+    private fun parseUuid(uuid: String): UUID =
+        try {
+            UUID.fromString(uuid)
+        } catch (e: IllegalArgumentException) {
+            throw ValidationException("Ugyldig uuid: $uuid")
+        }
 
 
     companion object {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQService.java
@@ -70,7 +70,7 @@ public class KafkaDLQService {
 
     @Transactional
     public void rekjørKafkaMelding(UUID uuid) {
-        KafkaDLQ kafkaDLQMelding = kafkaDLQRepository.findById(uuid).orElseThrow(() -> new NotFoundException("Kunne ikke finne KafkaDLQ-melding basert, uuid=" + uuid));
+        KafkaDLQ kafkaDLQMelding = hentMeldingEllerKast(uuid);
         if (kafkaDLQMelding instanceof SedMottattHendelseKafkaDLQ sedMottattHendelse) {
             rekjorSedMottattHendelse(sedMottattHendelse);
         } else if (kafkaDLQMelding instanceof SedSendtHendelseKafkaDLQ sedSendtHendelse) {
@@ -82,9 +82,14 @@ public class KafkaDLQService {
 
     @Transactional
     public void slettKafkaMelding(UUID uuid) {
-        KafkaDLQ kafkaDLQMelding = kafkaDLQRepository.findById(uuid).orElseThrow(() -> new NotFoundException("Kunne ikke finne KafkaDLQ-melding basert, uuid=" + uuid));
+        KafkaDLQ kafkaDLQMelding = hentMeldingEllerKast(uuid);
         log.info("Sletter KafkaDLQ-melding fra DLQ uten prosessering, uuid={}, queueType={}", uuid, kafkaDLQMelding.getQueueType());
         kafkaDLQRepository.delete(kafkaDLQMelding);
+    }
+
+    private KafkaDLQ hentMeldingEllerKast(UUID uuid) {
+        return kafkaDLQRepository.findById(uuid)
+            .orElseThrow(() -> new NotFoundException("Kunne ikke finne KafkaDLQ-melding basert på uuid=" + uuid));
     }
 
     private void rekjorSedMottattHendelse(SedMottattHendelseKafkaDLQ sedMottattHendelseKafkaDLQ) {

--- a/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQService.java
+++ b/melosys-eessi-app/src/main/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQService.java
@@ -80,6 +80,13 @@ public class KafkaDLQService {
         }
     }
 
+    @Transactional
+    public void slettKafkaMelding(UUID uuid) {
+        KafkaDLQ kafkaDLQMelding = kafkaDLQRepository.findById(uuid).orElseThrow(() -> new NotFoundException("Kunne ikke finne KafkaDLQ-melding basert, uuid=" + uuid));
+        log.info("Sletter KafkaDLQ-melding fra DLQ uten prosessering, uuid={}, queueType={}", uuid, kafkaDLQMelding.getQueueType());
+        kafkaDLQRepository.delete(kafkaDLQMelding);
+    }
+
     private void rekjorSedMottattHendelse(SedMottattHendelseKafkaDLQ sedMottattHendelseKafkaDLQ) {
         SedHendelse sedHendelse = sedMottattHendelseKafkaDLQ.getSedMottattHendelse();
         putToMDC(SED_ID, sedHendelse.getSedId());

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQServiceTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQServiceTest.kt
@@ -1,6 +1,7 @@
 package no.nav.melosys.eessi.service.kafkadlq
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -42,6 +43,7 @@ internal class KafkaDLQServiceTest {
 
         kafkaDLQService.slettKafkaMelding(uuid)
 
+        verify(exactly = 1) { kafkaDLQRepository.findById(uuid) }
         verify(exactly = 1) { kafkaDLQRepository.delete(melding) }
     }
 
@@ -50,9 +52,10 @@ internal class KafkaDLQServiceTest {
         val uuid = UUID.randomUUID()
         every { kafkaDLQRepository.findById(uuid) } returns Optional.empty()
 
-        shouldThrow<NotFoundException> {
+        val exception = shouldThrow<NotFoundException> {
             kafkaDLQService.slettKafkaMelding(uuid)
         }
+        exception.message shouldContain uuid.toString()
 
         verify(exactly = 0) { kafkaDLQRepository.delete(any()) }
     }

--- a/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQServiceTest.kt
+++ b/melosys-eessi-app/src/test/java/no/nav/melosys/eessi/service/kafkadlq/KafkaDLQServiceTest.kt
@@ -1,0 +1,59 @@
+package no.nav.melosys.eessi.service.kafkadlq
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.melosys.eessi.models.exception.NotFoundException
+import no.nav.melosys.eessi.models.kafkadlq.KafkaDLQ
+import no.nav.melosys.eessi.models.kafkadlq.QueueType
+import no.nav.melosys.eessi.repository.KafkaDLQRepository
+import no.nav.melosys.eessi.service.journalfoering.OpprettUtgaaendeJournalpostService
+import no.nav.melosys.eessi.service.mottak.SedMottakService
+import no.nav.melosys.eessi.service.oppgave.OppgaveEndretService
+import org.junit.jupiter.api.Test
+import java.util.Optional
+import java.util.UUID
+
+internal class KafkaDLQServiceTest {
+
+    private val kafkaDLQRepository = mockk<KafkaDLQRepository>()
+    private val sedMottakService = mockk<SedMottakService>()
+    private val opprettUtgaaendeJournalpostService = mockk<OpprettUtgaaendeJournalpostService>()
+    private val oppgaveEndretService = mockk<OppgaveEndretService>()
+
+    private val kafkaDLQService = KafkaDLQService(
+        kafkaDLQRepository,
+        sedMottakService,
+        opprettUtgaaendeJournalpostService,
+        oppgaveEndretService
+    )
+
+    @Test
+    fun `slettKafkaMelding sletter melding når den finnes`() {
+        val uuid = UUID.randomUUID()
+        val melding = mockk<KafkaDLQ> {
+            every { queueType } returns QueueType.SED_MOTTATT_HENDELSE
+        }
+        every { kafkaDLQRepository.findById(uuid) } returns Optional.of(melding)
+        every { kafkaDLQRepository.delete(melding) } just Runs
+
+        kafkaDLQService.slettKafkaMelding(uuid)
+
+        verify(exactly = 1) { kafkaDLQRepository.delete(melding) }
+    }
+
+    @Test
+    fun `slettKafkaMelding kaster NotFoundException når melding ikke finnes`() {
+        val uuid = UUID.randomUUID()
+        every { kafkaDLQRepository.findById(uuid) } returns Optional.empty()
+
+        shouldThrow<NotFoundException> {
+            kafkaDLQService.slettKafkaMelding(uuid)
+        }
+
+        verify(exactly = 0) { kafkaDLQRepository.delete(any()) }
+    }
+}

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/AdminControllerAuthenticationIT.kt
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/AdminControllerAuthenticationIT.kt
@@ -10,6 +10,7 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
 
 /**
  * Tester for admin-kontroller autentisering som krever både API-nøkkel og bearer token.
@@ -135,5 +136,35 @@ class AdminControllerAuthenticationIT : ComponentTestBase() {
                 .accept(MediaType.APPLICATION_JSON)
         )
             .andExpect(MockMvcResultMatchers.status().isOk)
+    }
+
+    @Test
+    fun `skal kreve autentisering for DELETE på dlq endepunkt og gi 404 for ukjent melding`() {
+        val uuid = UUID.randomUUID()
+
+        // Uten autentisering
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/$uuid")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isInternalServerError)
+
+        // Feil API-nøkkel
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/$uuid")
+                .header(API_KEY_HEADER, "feil-api-nokkel")
+                .header("Authorization", "Bearer ${hentBearerToken()}")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isInternalServerError)
+
+        // Korrekt autentisering, men meldingen finnes ikke -> 404
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/$uuid")
+                .header(API_KEY_HEADER, GYLDIG_API_NOKKEL)
+                .header("Authorization", "Bearer ${hentBearerToken()}")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isNotFound)
     }
 }

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/AdminControllerAuthenticationIT.kt
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/AdminControllerAuthenticationIT.kt
@@ -167,4 +167,15 @@ class AdminControllerAuthenticationIT : ComponentTestBase() {
         )
             .andExpect(MockMvcResultMatchers.status().isNotFound)
     }
+
+    @Test
+    fun `skal gi 400 for ugyldig uuid på DELETE av dlq-melding`() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/ikke-en-gyldig-uuid")
+                .header(API_KEY_HEADER, GYLDIG_API_NOKKEL)
+                .header("Authorization", "Bearer ${hentBearerToken()}")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+    }
 }

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/AdminControllerAuthenticationIT.kt
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/AdminControllerAuthenticationIT.kt
@@ -139,7 +139,7 @@ class AdminControllerAuthenticationIT : ComponentTestBase() {
     }
 
     @Test
-    fun `skal kreve autentisering for DELETE på dlq endepunkt og gi 404 for ukjent melding`() {
+    fun `skal kreve autentisering for DELETE på dlq endepunkt`() {
         val uuid = UUID.randomUUID()
 
         // Uten autentisering
@@ -157,25 +157,5 @@ class AdminControllerAuthenticationIT : ComponentTestBase() {
                 .accept(MediaType.APPLICATION_JSON)
         )
             .andExpect(MockMvcResultMatchers.status().isInternalServerError)
-
-        // Korrekt autentisering, men meldingen finnes ikke -> 404
-        mockMvc.perform(
-            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/$uuid")
-                .header(API_KEY_HEADER, GYLDIG_API_NOKKEL)
-                .header("Authorization", "Bearer ${hentBearerToken()}")
-                .accept(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(MockMvcResultMatchers.status().isNotFound)
-    }
-
-    @Test
-    fun `skal gi 400 for ugyldig uuid på DELETE av dlq-melding`() {
-        mockMvc.perform(
-            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/ikke-en-gyldig-uuid")
-                .header(API_KEY_HEADER, GYLDIG_API_NOKKEL)
-                .header("Authorization", "Bearer ${hentBearerToken()}")
-                .accept(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(MockMvcResultMatchers.status().isBadRequest)
     }
 }

--- a/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/KafkaAdminTjenesteTestIT.kt
+++ b/melosys-eessi-test/src/test/java/no/nav/melosys/eessi/KafkaAdminTjenesteTestIT.kt
@@ -2,7 +2,10 @@ package no.nav.melosys.eessi
 
 import no.nav.melosys.eessi.controller.dto.KafkaConsumerResponse
 import no.nav.melosys.eessi.integration.oppgave.HentOppgaveDto
+import no.nav.melosys.eessi.models.kafkadlq.SedSendtHendelseKafkaDLQ
+import no.nav.melosys.eessi.repository.KafkaDLQRepository
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
@@ -14,6 +17,7 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.UUID
 import kotlin.random.Random
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import tools.jackson.databind.json.JsonMapper
@@ -36,6 +40,9 @@ class KafkaAdminTjenesteTestIT : ComponentTestBase() {
 
     @Autowired
     private lateinit var jsonMapper: JsonMapper
+
+    @Autowired
+    private lateinit var kafkaDLQRepository: KafkaDLQRepository
 
     private fun hentBearerToken(): String {
         return mockOAuth2Server.issueToken(
@@ -149,6 +156,48 @@ class KafkaAdminTjenesteTestIT : ComponentTestBase() {
 
         // Vi sender 4 meldinger, resetter til offset 2, melding med offset 2 og 3 leses på nytt, totalt hentes oppgave 6 ganger.
         verify(oppgaveConsumer, timeout(6_000).times(6)).hentOppgave(anyString())
+    }
+
+    @Test
+    fun `slettKafkaMelding sletter eksisterende melding og returnerer 204`() {
+        val id = UUID.randomUUID()
+        val melding = SedSendtHendelseKafkaDLQ().apply {
+            this.id = id
+            sedSendtHendelse = mockData.sedHendelse("rinasak", UUID.randomUUID().toString(), FNR)
+        }
+        kafkaDLQRepository.save(melding)
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/$id")
+                .header(API_KEY_HEADER, GYLDIG_API_NOKKEL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer ${hentBearerToken()}")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+        Assertions.assertThat(kafkaDLQRepository.findById(id)).isEmpty()
+    }
+
+    @Test
+    fun `slettKafkaMelding returnerer 404 når melding ikke finnes`() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/${UUID.randomUUID()}")
+                .header(API_KEY_HEADER, GYLDIG_API_NOKKEL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer ${hentBearerToken()}")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isNotFound)
+    }
+
+    @Test
+    fun `slettKafkaMelding returnerer 400 ved ugyldig uuid`() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/admin/kafka/dlq/ikke-en-gyldig-uuid")
+                .header(API_KEY_HEADER, GYLDIG_API_NOKKEL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer ${hentBearerToken()}")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
     }
 
 }


### PR DESCRIPTION
Legger til et admin-endepunkt for å slette en feilet melding fra Kafka-DLQ uten å prosessere den.

Enkelte feilede meldinger skal aldri prosesseres – f.eks. en SED med ugyldig kombinasjon av BUC og SED – og blir liggende og fylle opp DLQ-en. Tidligere fantes ingen måte å fjerne dem på utenom manuelle databaseoperasjoner. Endepunktet gir drift en kontrollert måte å rydde bort slike meldinger.
[MELOSYS-8127](https://jira.adeo.no/browse/MELOSYS-8127)

- Nytt `DELETE /admin/kafka/dlq/{uuid}`-endepunkt som sletter en feilet melding uten prosessering
- Validerer uuid (ugyldig uuid gir 400) og dokumenterer 204/404/400 i OpenAPI
- Trekker ut felles oppslag av KafkaDLQ-melding til en hjelpemetode
- Enhetstester og integrasjonstest for autentisering og 404

## Testing
- [x] Enhetstester (KafkaDLQServiceTest – kjørt lokalt, 2/2 grønne)
- [x] Integrasjonstest (AdminControllerAuthenticationIT – kompilerer, ikke kjørt lokalt pga. Docker/Testcontainers)
- [ ] Manuell testing lokalt